### PR TITLE
Redesign product catalog

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -167,29 +167,71 @@ section {
 
 .catalog {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
-  gap: 20px;
+  gap: 30px;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 600px) {
+  .catalog {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .catalog {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 
 .product-card {
-  background: #fff;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  padding: 10px;
-  text-align: center;
-  transition: transform 0.3s, box-shadow 0.3s;
+  position: relative;
+  display: block;
+  height: 300px;
+  overflow: hidden;
+  text-decoration: none;
+  background-color: #eee;
 }
 
-.product-card:hover {
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-  transform: translateY(-3px);
+.product-card:hover .product-image {
+  transform: scale(1.05);
 }
 
 .product-image {
   width: 100%;
-  height: 150px;
+  height: 100%;
   background: linear-gradient(135deg, #fafafa, #eaeaea);
-  margin-bottom: 10px;
+  background-size: cover;
+  background-position: center;
+  transition: transform 0.3s ease;
+}
+
+.product-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.4);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+  color: #fff;
+  transition: background 0.3s ease;
+}
+
+.product-overlay h3 {
+  margin: 0;
+  font-size: 1.2em;
+  font-weight: 600;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+}
+
+.product-overlay .price {
+  margin-top: 6px;
+  font-size: 1em;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
 }
 
 /* Reviews grid */
@@ -408,20 +450,12 @@ footer {
     display: none;
   }
 
-  .catalog {
-    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  }
-
   .reviews-grid {
     gap: 20px;
   }
 }
 
 @media (max-width: 480px) {
-  .catalog {
-    grid-template-columns: 1fr;
-  }
-
   .reviews-grid {
     flex-direction: column;
     align-items: center;

--- a/catalog.html
+++ b/catalog.html
@@ -34,30 +34,34 @@
     <div class="container fade-in">
       <h1>Каталог товаров</h1>
       <div class="catalog">
-        <div class="product-card">
+        <a href="#" class="product-card">
           <div class="product-image"></div>
-          <h3>Смартфон X1</h3>
-          <p>Современный дизайн и высокая производительность.</p>
-          <strong>₽ 49&nbsp;990</strong>
-        </div>
-        <div class="product-card">
+          <div class="product-overlay">
+            <h3>Смартфон X1</h3>
+            <span class="price">₽ 49&nbsp;990</span>
+          </div>
+        </a>
+        <a href="#" class="product-card">
           <div class="product-image"></div>
-          <h3>Наушники Y2</h3>
-          <p>Качественный звук в компактном корпусе.</p>
-          <strong>₽ 6&nbsp;990</strong>
-        </div>
-        <div class="product-card">
+          <div class="product-overlay">
+            <h3>Наушники Y2</h3>
+            <span class="price">₽ 6&nbsp;990</span>
+          </div>
+        </a>
+        <a href="#" class="product-card">
           <div class="product-image"></div>
-          <h3>Планшет Z3</h3>
-          <p>Широкий экран и ёмкая батарея для работы и игр.</p>
-          <strong>₽ 29&nbsp;990</strong>
-        </div>
-        <div class="product-card">
+          <div class="product-overlay">
+            <h3>Планшет Z3</h3>
+            <span class="price">₽ 29&nbsp;990</span>
+          </div>
+        </a>
+        <a href="#" class="product-card">
           <div class="product-image"></div>
-          <h3>Смарт-часы W4</h3>
-          <p>Отслеживание активности и уведомления на запястье.</p>
-          <strong>₽ 14&nbsp;990</strong>
-        </div>
+          <div class="product-overlay">
+            <h3>Смарт-часы W4</h3>
+            <span class="price">₽ 14&nbsp;990</span>
+          </div>
+        </a>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -59,30 +59,34 @@
       <div class="container">
         <h2>Каталог товаров</h2>
         <div class="catalog">
-          <div class="product-card">
+          <a href="#" class="product-card">
             <div class="product-image"></div>
-            <h3>Смартфон X1</h3>
-            <p>Современный дизайн и высокая производительность.</p>
-            <strong>₽ 49&nbsp;990</strong>
-          </div>
-          <div class="product-card">
+            <div class="product-overlay">
+              <h3>Смартфон X1</h3>
+              <span class="price">₽ 49&nbsp;990</span>
+            </div>
+          </a>
+          <a href="#" class="product-card">
             <div class="product-image"></div>
-            <h3>Наушники Y2</h3>
-            <p>Качественный звук в компактном корпусе.</p>
-            <strong>₽ 6&nbsp;990</strong>
-          </div>
-          <div class="product-card">
+            <div class="product-overlay">
+              <h3>Наушники Y2</h3>
+              <span class="price">₽ 6&nbsp;990</span>
+            </div>
+          </a>
+          <a href="#" class="product-card">
             <div class="product-image"></div>
-            <h3>Планшет Z3</h3>
-            <p>Широкий экран и ёмкая батарея для работы и игр.</p>
-            <strong>₽ 29&nbsp;990</strong>
-          </div>
-          <div class="product-card">
+            <div class="product-overlay">
+              <h3>Планшет Z3</h3>
+              <span class="price">₽ 29&nbsp;990</span>
+            </div>
+          </a>
+          <a href="#" class="product-card">
             <div class="product-image"></div>
-            <h3>Смарт-часы W4</h3>
-            <p>Отслеживание активности и уведомления на запястье.</p>
-            <strong>₽ 14&nbsp;990</strong>
-          </div>
+            <div class="product-overlay">
+              <h3>Смарт-часы W4</h3>
+              <span class="price">₽ 14&nbsp;990</span>
+            </div>
+          </a>
         </div>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- transform catalog product cards into clickable promo-style tiles
- overlay text and price on top of images for a minimalist look
- update catalog layout and hover effects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687a9f366404832cbd9339c53cec4e87