### PR TITLE
Add top sales carousel

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -60,4 +60,23 @@ document.addEventListener('DOMContentLoaded', () => {
     }, { threshold: 0.1 });
 
     document.querySelectorAll('.fade-in').forEach(el => observer.observe(el));
+
+    if (window.Swiper) {
+        new Swiper('.top-sales-swiper', {
+            slidesPerView: 1,
+            spaceBetween: 30,
+            navigation: {
+                nextEl: '.top-sales-swiper .swiper-button-next',
+                prevEl: '.top-sales-swiper .swiper-button-prev',
+            },
+            pagination: {
+                el: '.top-sales-swiper .swiper-pagination',
+                clickable: true,
+            },
+            breakpoints: {
+                600: { slidesPerView: 2 },
+                1024: { slidesPerView: 3 },
+            },
+        });
+    }
 });

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -575,3 +575,91 @@ footer {
     transform: translateX(-50%);
   }
 }
+
+/* Top Sales section */
+.top-sales-heading {
+  font-weight: bold;
+  font-size: 32px;
+  margin-bottom: 40px;
+  text-transform: uppercase;
+  text-align: center;
+}
+
+.top-sales-swiper {
+  position: relative;
+  padding-bottom: 40px;
+}
+
+.top-sales-swiper .swiper-slide {
+  display: flex;
+  justify-content: center;
+}
+
+.sales-card {
+  background: #fff;
+  border-radius: 6px;
+  padding: 20px;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.05);
+  width: 320px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.sales-card .placeholder {
+  width: 100%;
+  height: 240px;
+  background-color: #eee;
+  border-radius: 4px;
+}
+
+.sales-card .specs {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  font-size: 14px;
+  text-align: center;
+}
+
+.sales-card .specs li + li {
+  margin-top: 4px;
+}
+
+.sales-card .price {
+  background: #000;
+  color: #fff;
+  font-weight: bold;
+  padding: 8px 12px;
+  border-radius: 4px;
+}
+
+.sales-card button {
+  background: #fff;
+  border: 1px solid #000;
+  padding: 8px 16px;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.sales-card button:hover {
+  background: #000;
+  color: #fff;
+}
+
+.top-sales-swiper .swiper-pagination-bullet {
+  width: 12px;
+  height: 12px;
+  background: #ccc;
+  opacity: 1;
+  margin: 0 4px !important;
+}
+
+.top-sales-swiper .swiper-pagination-bullet-active {
+  background: #000;
+}
+
+.top-sales-swiper .swiper-button-prev,
+.top-sales-swiper .swiper-button-next {
+  color: #000;
+}

--- a/index.html
+++ b/index.html
@@ -7,6 +7,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
     <link rel="stylesheet" href="assets/styles.css" />
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.css"
+    />
   </head>
   <body>
     <header>
@@ -119,7 +123,86 @@
 
     <section id="top-sales" class="fade-in section-background">
       <div class="container">
-        <h2>ТОП ПРОДАЖ</h2>
+        <h2 class="top-sales-heading">ТОП ПРОДАЖ</h2>
+        <div class="swiper top-sales-swiper">
+          <div class="swiper-wrapper">
+            <div class="swiper-slide">
+              <div class="sales-card">
+                <div class="placeholder"></div>
+                <h3 class="phone-name">Apple iPhone X Pro</h3>
+                <ul class="specs">
+                  <li>Память: 128GB / 256GB / 512GB</li>
+                  <li>Цвет: Серый / Белый / Чёрный</li>
+                </ul>
+                <div class="price">Цена: 94 990Р</div>
+                <button>Купить</button>
+              </div>
+            </div>
+            <div class="swiper-slide">
+              <div class="sales-card">
+                <div class="placeholder"></div>
+                <h3 class="phone-name">Apple iPhone 11 Plus</h3>
+                <ul class="specs">
+                  <li>Память: 128GB / 256GB</li>
+                  <li>Цвет: Белый / Жёлтый / Чёрный</li>
+                </ul>
+                <div class="price">Цена: 84 990Р</div>
+                <button>Купить</button>
+              </div>
+            </div>
+            <div class="swiper-slide">
+              <div class="sales-card">
+                <div class="placeholder"></div>
+                <h3 class="phone-name">Apple iPhone 12 Mini</h3>
+                <ul class="specs">
+                  <li>Память: 64GB / 128GB / 256GB</li>
+                  <li>Цвет: Красный / Синий / Чёрный</li>
+                </ul>
+                <div class="price">Цена: 69 990Р</div>
+                <button>Купить</button>
+              </div>
+            </div>
+            <div class="swiper-slide">
+              <div class="sales-card">
+                <div class="placeholder"></div>
+                <h3 class="phone-name">Apple iPhone 13 Pro</h3>
+                <ul class="specs">
+                  <li>Память: 128GB / 256GB / 512GB</li>
+                  <li>Цвет: Серебристый / Графитовый / Золотой</li>
+                </ul>
+                <div class="price">Цена: 114 990Р</div>
+                <button>Купить</button>
+              </div>
+            </div>
+            <div class="swiper-slide">
+              <div class="sales-card">
+                <div class="placeholder"></div>
+                <h3 class="phone-name">Apple iPhone 14 Pro Max</h3>
+                <ul class="specs">
+                  <li>Память: 256GB / 512GB / 1TB</li>
+                  <li>Цвет: Фиолетовый / Зелёный / Чёрный</li>
+                </ul>
+                <div class="price">Цена: 159 990Р</div>
+                <button>Купить</button>
+              </div>
+            </div>
+            <div class="swiper-slide">
+              <div class="sales-card">
+                <div class="placeholder"></div>
+                <h3 class="phone-name">Apple iPhone SE 2022</h3>
+                <ul class="specs">
+                  <li>Память: 64GB / 128GB / 256GB</li>
+                  <li>Цвет: Красный / Белый / Чёрный</li>
+                </ul>
+                <div class="price">Цена: 49 990Р</div>
+                <button>Купить</button>
+              </div>
+            </div>
+          </div>
+          <div class="swiper-button-prev"></div>
+          <div class="swiper-button-next"></div>
+          <div class="swiper-pagination"></div>
+        </div>
       </div>
     </section>
 
@@ -289,6 +372,7 @@
       </div>
     </div>
 
-    <script src="assets/script.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/swiper@9/swiper-bundle.min.js"></script>
+      <script src="assets/script.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add "Top Sales" carousel section with 6 phone cards
- style carousel with Swiper and responsive design
- initialize Swiper in script
- include Swiper assets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b43f56e2c832c883013b43457cc87