### PR TITLE
feat: add apple-style catalog grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>iStore Shop</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <!-- Каталог товаров в стиле Apple -->
+  <section id="catalog" class="catalog-section">
+    <div class="catalog-grid">
+      <div class="catalog-item">
+        <img src="https://via.placeholder.com/300x200?text=iPad" alt="iPad" />
+        <h3>iPad Air</h3>
+        <p>Теперь с чипом M3</p>
+        <div class="catalog-buttons">
+          <a href="#" class="btn btn-blue">Узнать больше</a>
+          <a href="#" class="btn btn-outline">Купить</a>
+        </div>
+      </div>
+      <div class="catalog-item">
+        <img src="https://via.placeholder.com/300x200?text=MacBook" alt="MacBook" />
+        <h3>MacBook Air</h3>
+        <p>Чип M4, небесно-голубой</p>
+        <div class="catalog-buttons">
+          <a href="#" class="btn btn-blue">Узнать больше</a>
+          <a href="#" class="btn btn-outline">Купить</a>
+        </div>
+      </div>
+      <div class="catalog-item">
+        <img src="https://via.placeholder.com/300x200?text=iPhone" alt="iPhone" />
+        <h3>iPhone 15</h3>
+        <p>Новый дизайн, больше возможностей</p>
+        <div class="catalog-buttons">
+          <a href="#" class="btn btn-blue">Узнать больше</a>
+          <a href="#" class="btn btn-outline">Купить</a>
+        </div>
+      </div>
+      <div class="catalog-item">
+        <img src="https://via.placeholder.com/300x200?text=Watch" alt="Apple Watch" />
+        <h3>Apple Watch Series 9</h3>
+        <p>Лучший спутник на каждый день</p>
+        <div class="catalog-buttons">
+          <a href="#" class="btn btn-blue">Узнать больше</a>
+          <a href="#" class="btn btn-outline">Купить</a>
+        </div>
+      </div>
+      <div class="catalog-item">
+        <img src="https://via.placeholder.com/300x200?text=AirPods" alt="AirPods" />
+        <h3>AirPods Pro</h3>
+        <p>Новый уровень звука</p>
+        <div class="catalog-buttons">
+          <a href="#" class="btn btn-blue">Узнать больше</a>
+          <a href="#" class="btn btn-outline">Купить</a>
+        </div>
+      </div>
+      <div class="catalog-item">
+        <img src="https://via.placeholder.com/300x200?text=iMac" alt="iMac" />
+        <h3>iMac</h3>
+        <p>Мощь и стиль для работы и творчества</p>
+        <div class="catalog-buttons">
+          <a href="#" class="btn btn-blue">Узнать больше</a>
+          <a href="#" class="btn btn-outline">Купить</a>
+        </div>
+      </div>
+    </div>
+  </section>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,57 @@
+/* Каталог товаров в стиле Apple */
+.catalog-section {
+  padding: 0;
+  background: #f5f5f7;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 12px;
+  max-width: 100%;
+  margin: 0;
+}
+
+.catalog-item {
+  background: #fff;
+  padding: 40px 20px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border: 1px solid #eaeaea;
+  border-radius: 8px;
+}
+
+.catalog-item img {
+  width: 70%;
+  margin: 0 auto 20px;
+}
+
+.catalog-buttons {
+  margin-top: 20px;
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+}
+
+.btn {
+  padding: 10px 20px;
+  font-weight: 500;
+  text-decoration: none;
+  border-radius: 30px;
+  font-size: 14px;
+}
+
+.btn-blue {
+  background-color: #0071e3;
+  color: #fff;
+}
+
+.btn-outline {
+  border: 1px solid #0071e3;
+  color: #0071e3;
+  background: transparent;
+}


### PR DESCRIPTION
## Summary
- add full-width catalog section with six Apple-style product cards
- replace local PNG assets with placeholder URLs to remove binary files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2a6870f3c832cba200f341456c3d6