### PR TITLE
Add responsive catalog grid with uniform product cards

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -665,31 +665,34 @@ footer {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 12px;
-  max-width: 100%;
-  margin: 0;
+  width: 100vw;
 }
 
 .catalog-item {
-  background: #fff;
-  padding: 40px 20px;
-  text-align: center;
+  height: calc(100vw / 2 * 0.65);
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  border: 1px solid #eaeaea;
-  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid #fff;
+}
+.catalog-image {
+  flex: 1;
 }
 
-.catalog-item img {
-  width: 70%;
-  margin: 0 auto 20px;
-  background: #ddd;
-  aspect-ratio: 1/1;
-  object-fit: contain;
+.catalog-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.catalog-content {
+  padding: 16px;
+  text-align: center;
+  background: #fff;
 }
 
 .catalog-buttons {
-  margin-top: 20px;
+  margin-top: 16px;
   display: flex;
   justify-content: center;
   gap: 12px;

--- a/catalog.html
+++ b/catalog.html
@@ -60,57 +60,69 @@
         <h1>Каталог товаров</h1>
         <div class="catalog-grid">
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="iPad" />
-            <h3>iPad Air</h3>
-            <p>Теперь с чипом M3</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image"><img src="https://placehold.co/600x390?text=iPad%20Air" alt="iPad Air" /></div>
+            <div class="catalog-content">
+              <h3>iPad Air</h3>
+              <p>Теперь с чипом M3</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="MacBook" />
-            <h3>MacBook Air</h3>
-            <p>Чип M4, небесно-голубой</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image"><img src="https://placehold.co/600x390?text=MacBook%20Air" alt="MacBook Air" /></div>
+            <div class="catalog-content">
+              <h3>MacBook Air</h3>
+              <p>Чип M4, небесно-голубой</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="iPhone" />
-            <h3>iPhone 15</h3>
-            <p>Теперь с USB‑C</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image"><img src="https://placehold.co/600x390?text=Apple%20Watch" alt="Apple Watch" /></div>
+            <div class="catalog-content">
+              <h3>Apple Watch</h3>
+              <p>Следите за здоровьем</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Apple Watch" />
-            <h3>Apple Watch</h3>
-            <p>Следите за здоровьем</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image"><img src="https://placehold.co/600x390?text=iPhone%2015" alt="iPhone 15" /></div>
+            <div class="catalog-content">
+              <h3>iPhone 15</h3>
+              <p>Теперь с USB‑C</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="AirPods" />
-            <h3>AirPods Pro</h3>
-            <p>Звук нового уровня</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image"><img src="https://placehold.co/600x390?text=AirPods%20Pro" alt="AirPods Pro" /></div>
+            <div class="catalog-content">
+              <h3>AirPods Pro</h3>
+              <p>Звук нового уровня</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="iMac" />
-            <h3>iMac 24″</h3>
-            <p>В цветах, которые вдохновляют</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image"><img src="https://placehold.co/600x390?text=Mac%20Pro" alt="Mac Pro" /></div>
+            <div class="catalog-content">
+              <h3>Mac Pro</h3>
+              <p>Мощность для профессионалов</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -96,57 +96,69 @@
       <section id="catalog" class="catalog-section">
         <div class="catalog-grid">
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="iPad" />
-            <h3>iPad Air</h3>
-            <p>Теперь с чипом M3</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image"><img src="https://placehold.co/600x390?text=iPad%20Air" alt="iPad Air" /></div>
+            <div class="catalog-content">
+              <h3>iPad Air</h3>
+              <p>Теперь с чипом M3</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="MacBook" />
-            <h3>MacBook Air</h3>
-            <p>Чип M4, небесно-голубой</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image"><img src="https://placehold.co/600x390?text=MacBook%20Air" alt="MacBook Air" /></div>
+            <div class="catalog-content">
+              <h3>MacBook Air</h3>
+              <p>Чип M4, небесно-голубой</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="iPhone" />
-            <h3>iPhone 15</h3>
-            <p>Теперь с USB‑C</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image"><img src="https://placehold.co/600x390?text=Apple%20Watch" alt="Apple Watch" /></div>
+            <div class="catalog-content">
+              <h3>Apple Watch</h3>
+              <p>Следите за здоровьем</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Apple Watch" />
-            <h3>Apple Watch</h3>
-            <p>Следите за здоровьем</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image"><img src="https://placehold.co/600x390?text=iPhone%2015" alt="iPhone 15" /></div>
+            <div class="catalog-content">
+              <h3>iPhone 15</h3>
+              <p>Теперь с USB‑C</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="AirPods" />
-            <h3>AirPods Pro</h3>
-            <p>Звук нового уровня</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image"><img src="https://placehold.co/600x390?text=AirPods%20Pro" alt="AirPods Pro" /></div>
+            <div class="catalog-content">
+              <h3>AirPods Pro</h3>
+              <p>Звук нового уровня</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="iMac" />
-            <h3>iMac 24″</h3>
-            <p>В цветах, которые вдохновляют</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image"><img src="https://placehold.co/600x390?text=Mac%20Pro" alt="Mac Pro" /></div>
+            <div class="catalog-content">
+              <h3>Mac Pro</h3>
+              <p>Мощность для профессионалов</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace local product PNGs with remote placeholder images and remove bundled assets
- Keep full-width 2x3 catalog grid with uniform card sizing and buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b7a5dac0832c8dbf39a15d6984f7