### PR TITLE
Implement responsive 2x3 product catalog grid

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -663,35 +663,37 @@ footer {
 
 .catalog-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr); /* 2 колонки */
+  grid-template-columns: repeat(2, 1fr);
   gap: 12px;
-  width: 100vw; /* на всю ширину экрана */
-  margin: 0;
-  padding: 0;
-  box-sizing: border-box;
+  width: 100vw;
 }
 
 .catalog-item {
-  background: #fff;
-  aspect-ratio: 1 / 0.65; /* ширина : высота → 100:65 */
+  height: calc(100vw / 2 * 0.65);
   display: flex;
   flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  padding: 24px;
-  border: 1px solid #eaeaea;
-  border-radius: 8px;
-  box-sizing: border-box;
+  overflow: hidden;
+  background: #fff;
+  border: 1px solid #fff;
 }
 
-.catalog-item img {
-  max-width: 80%;
-  height: auto;
-  margin-bottom: 12px;
+.catalog-image {
+  flex: 1;
+}
+
+.catalog-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.catalog-content {
+  padding: 16px;
+  text-align: center;
 }
 
 .catalog-buttons {
-  margin-top: 20px;
+  margin-top: 12px;
   display: flex;
   justify-content: center;
   gap: 12px;

--- a/catalog.html
+++ b/catalog.html
@@ -60,57 +60,81 @@
         <h1>Каталог товаров</h1>
         <div class="catalog-grid">
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="iPad" />
-            <h3>iPad Air</h3>
-            <p>Теперь с чипом M3</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image">
+              <img src="assets/images/ipad.png" alt="iPad Air" />
+            </div>
+            <div class="catalog-content">
+              <h3>iPad Air</h3>
+              <p>Теперь с чипом M3</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="MacBook" />
-            <h3>MacBook Air</h3>
-            <p>Чип M4, небесно-голубой</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image">
+              <img src="assets/images/macbook.png" alt="MacBook Air" />
+            </div>
+            <div class="catalog-content">
+              <h3>MacBook Air</h3>
+              <p>Чип M4, небесно-голубой</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="iPhone" />
-            <h3>iPhone 15</h3>
-            <p>Теперь с USB‑C</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image">
+              <img src="assets/images/watch.png" alt="Apple Watch" />
+            </div>
+            <div class="catalog-content">
+              <h3>Apple Watch</h3>
+              <p>Следите за здоровьем</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Apple Watch" />
-            <h3>Apple Watch</h3>
-            <p>Следите за здоровьем</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image">
+              <img src="assets/images/iphone.png" alt="iPhone 15" />
+            </div>
+            <div class="catalog-content">
+              <h3>iPhone 15</h3>
+              <p>Теперь с USB‑C</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="AirPods" />
-            <h3>AirPods Pro</h3>
-            <p>Звук нового уровня</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image">
+              <img src="assets/images/airpods.png" alt="AirPods Pro" />
+            </div>
+            <div class="catalog-content">
+              <h3>AirPods Pro</h3>
+              <p>Звук нового уровня</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="iMac" />
-            <h3>iMac 24″</h3>
-            <p>В цветах, которые вдохновляют</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image">
+              <img src="assets/images/mac.png" alt="iMac 24″" />
+            </div>
+            <div class="catalog-content">
+              <h3>iMac 24″</h3>
+              <p>В цветах, которые вдохновляют</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -96,57 +96,81 @@
       <section id="catalog" class="catalog-section">
         <div class="catalog-grid">
           <div class="catalog-item">
-            <img src="C:\Users\stanl\istore-shop\assets\images\item1.png" alt="iPad" />
-            <h3>iPad Air</h3>
-            <p>Теперь с чипом M3</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image">
+              <img src="assets/images/ipad.png" alt="iPad Air" />
+            </div>
+            <div class="catalog-content">
+              <h3>iPad Air</h3>
+              <p>Теперь с чипом M3</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="MacBook" />
-            <h3>MacBook Air</h3>
-            <p>Чип M4, небесно-голубой</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image">
+              <img src="assets/images/macbook.png" alt="MacBook Air" />
+            </div>
+            <div class="catalog-content">
+              <h3>MacBook Air</h3>
+              <p>Чип M4, небесно-голубой</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="iPhone" />
-            <h3>iPhone 15</h3>
-            <p>Теперь с USB‑C</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image">
+              <img src="assets/images/watch.png" alt="Apple Watch" />
+            </div>
+            <div class="catalog-content">
+              <h3>Apple Watch</h3>
+              <p>Следите за здоровьем</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="Apple Watch" />
-            <h3>Apple Watch</h3>
-            <p>Следите за здоровьем</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image">
+              <img src="assets/images/iphone.png" alt="iPhone 15" />
+            </div>
+            <div class="catalog-content">
+              <h3>iPhone 15</h3>
+              <p>Теперь с USB‑C</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="AirPods" />
-            <h3>AirPods Pro</h3>
-            <p>Звук нового уровня</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image">
+              <img src="assets/images/airpods.png" alt="AirPods Pro" />
+            </div>
+            <div class="catalog-content">
+              <h3>AirPods Pro</h3>
+              <p>Звук нового уровня</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
           <div class="catalog-item">
-            <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="iMac" />
-            <h3>iMac 24″</h3>
-            <p>В цветах, которые вдохновляют</p>
-            <div class="catalog-buttons">
-              <a href="#" class="btn btn-blue">Узнать больше</a>
-              <a href="#" class="btn btn-outline">Купить</a>
+            <div class="catalog-image">
+              <img src="assets/images/mac.png" alt="iMac 24″" />
+            </div>
+            <div class="catalog-content">
+              <h3>iMac 24″</h3>
+              <p>В цветах, которые вдохновляют</p>
+              <div class="catalog-buttons">
+                <a href="#" class="btn btn-blue">Узнать больше</a>
+                <a href="#" class="btn btn-outline">Купить</a>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace catalog section markup with six product cards using uniform image and button layout
- Style catalog grid as 2x3 responsive layout with cover images and button styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ba72dd90832cbec77a5b2d7652f5