### PR TITLE
feat: animate catalog tiles

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -661,28 +661,46 @@ footer {
   box-sizing: border-box;
 }
 
+
 .catalog-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 12px;
-  width: 100%;
+  display: flex;
+  gap: 20px;
+  padding: 0 40px;
 }
 
 .catalog-item {
   position: relative;
-  height: calc(100vw / 2 * 0.65);
+  border-radius: 12px;
   overflow: hidden;
-  border: 1px solid #fff;
+  height: calc(100vw / 2 * 0.6);
+  transition: all 0.4s ease;
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
 }
 
 .catalog-item img {
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 100%;
   height: 100%;
   object-fit: cover;
-  z-index: 0;
+  transition: transform 0.4s ease;
+}
+
+.catalog-item:hover img {
+  transform: scale(1.08);
+}
+
+/* Эффект "расширения/сжатия" соседей */
+.catalog-grid:hover .catalog-item {
+  flex: 1;
+}
+
+.catalog-item:hover {
+  flex: 1.2;
+}
+
+.catalog-item:not(:hover) {
+  flex: 0.8;
 }
 
 .catalog-content {
@@ -721,6 +739,14 @@ footer {
 }
 
 @media (max-width: 768px) {
+  .catalog-grid {
+    flex-direction: column;
+    padding: 0 16px;
+  }
+  .catalog-item {
+    flex: auto;
+    height: 240px;
+  }
   .catalog-content { top: 6%; height: 88%; }
   .catalog-header h3 { font-size: clamp(22px, 7vw, 30px); }
   .catalog-header p { font-size: clamp(13px, 3.5vw, 16px); }


### PR DESCRIPTION
## Summary
- refine catalog layout using flex with side padding
- add rounded tiles with hover expansion and image scale
- ensure column layout on small screens

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bae642fdf4832cb8c186ac2319d9e4