### PR TITLE
feat: animate catalog tiles on hover

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -87,17 +87,17 @@ document.addEventListener('DOMContentLoaded', () => {
     catalogItems.forEach((item, idx) => {
         item.addEventListener('mouseenter', () => {
             const pairIndex = idx % 2 === 0 ? idx + 1 : idx - 1;
-            item.style.flexBasis = `calc(${expand}% - 6px)`;
+            item.style.flex = `0 0 calc(${expand}% - 6px)`;
             if (catalogItems[pairIndex]) {
-                catalogItems[pairIndex].style.flexBasis = `calc(${shrink}% - 6px)`;
+                catalogItems[pairIndex].style.flex = `0 0 calc(${shrink}% - 6px)`;
             }
         });
 
         item.addEventListener('mouseleave', () => {
             const pairIndex = idx % 2 === 0 ? idx + 1 : idx - 1;
-            item.style.flexBasis = '';
+            item.style.flex = '';
             if (catalogItems[pairIndex]) {
-                catalogItems[pairIndex].style.flexBasis = '';
+                catalogItems[pairIndex].style.flex = '';
             }
         });
     });

--- a/assets/script.js
+++ b/assets/script.js
@@ -81,23 +81,23 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     const catalogItems = document.querySelectorAll('.catalog-grid .catalog-item');
-    const expand = 55;
-    const shrink = 45;
+    const expand = 'calc(55% - 6px)';
+    const shrink = 'calc(45% - 6px)';
 
     catalogItems.forEach((item, idx) => {
         item.addEventListener('mouseenter', () => {
             const pairIndex = idx % 2 === 0 ? idx + 1 : idx - 1;
-            item.style.flex = `0 0 calc(${expand}% - 6px)`;
+            item.style.flexBasis = expand;
             if (catalogItems[pairIndex]) {
-                catalogItems[pairIndex].style.flex = `0 0 calc(${shrink}% - 6px)`;
+                catalogItems[pairIndex].style.flexBasis = shrink;
             }
         });
 
         item.addEventListener('mouseleave', () => {
             const pairIndex = idx % 2 === 0 ? idx + 1 : idx - 1;
-            item.style.flex = '';
+            item.style.flexBasis = '';
             if (catalogItems[pairIndex]) {
-                catalogItems[pairIndex].style.flex = '';
+                catalogItems[pairIndex].style.flexBasis = '';
             }
         });
     });

--- a/assets/script.js
+++ b/assets/script.js
@@ -79,4 +79,26 @@ document.addEventListener('DOMContentLoaded', () => {
             },
         });
     }
+
+    const catalogItems = document.querySelectorAll('.catalog-grid .catalog-item');
+    const expand = 55;
+    const shrink = 45;
+
+    catalogItems.forEach((item, idx) => {
+        item.addEventListener('mouseenter', () => {
+            const pairIndex = idx % 2 === 0 ? idx + 1 : idx - 1;
+            item.style.flexBasis = `calc(${expand}% - 6px)`;
+            if (catalogItems[pairIndex]) {
+                catalogItems[pairIndex].style.flexBasis = `calc(${shrink}% - 6px)`;
+            }
+        });
+
+        item.addEventListener('mouseleave', () => {
+            const pairIndex = idx % 2 === 0 ? idx + 1 : idx - 1;
+            item.style.flexBasis = '';
+            if (catalogItems[pairIndex]) {
+                catalogItems[pairIndex].style.flexBasis = '';
+            }
+        });
+    });
 });

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -654,6 +654,7 @@ footer {
 }
 
 /* Каталог товаров в стиле Apple */
+
 .catalog-section {
   padding: 0;
   background: #f5f5f7;
@@ -662,20 +663,25 @@ footer {
 }
 
 .catalog-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  display: flex;
+  flex-wrap: wrap;
   gap: 12px;
   width: 100%;
+  padding: 0 40px;
+  box-sizing: border-box;
 }
 
 .catalog-item {
   position: relative;
-  height: calc(100vw / 2 * 0.65);
+  flex: 1 1 calc(50% - 6px);
   overflow: hidden;
   border: 1px solid #fff;
+  border-radius: 12px;
+  aspect-ratio: 1 / 0.65;
+  transition: flex-basis 0.3s ease;
 }
 
-.catalog-item img {
+.catalog-image img {
   position: absolute;
   top: 0;
   left: 0;
@@ -683,6 +689,11 @@ footer {
   height: 100%;
   object-fit: cover;
   z-index: 0;
+  transition: transform 0.3s ease;
+}
+
+.catalog-item:hover .catalog-image img {
+  transform: scale(1.05);
 }
 
 .catalog-content {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -674,14 +674,15 @@ footer {
 .catalog-item {
   position: relative;
   flex: 0 0 calc(50% - 6px);
+  box-sizing: border-box;
   overflow: hidden;
   border: 1px solid #fff;
   border-radius: 12px;
   aspect-ratio: 1 / 0.65;
-  transition: flex 0.3s ease;
+  transition: flex-basis 0.3s ease;
 }
 
-.catalog-image img {
+.catalog-item img {
   position: absolute;
   top: 0;
   left: 0;
@@ -692,7 +693,7 @@ footer {
   transition: transform 0.3s ease;
 }
 
-.catalog-item:hover .catalog-image img {
+.catalog-item:hover img {
   transform: scale(1.05);
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -673,12 +673,12 @@ footer {
 
 .catalog-item {
   position: relative;
-  flex: 1 1 calc(50% - 6px);
+  flex: 0 0 calc(50% - 6px);
   overflow: hidden;
   border: 1px solid #fff;
   border-radius: 12px;
   aspect-ratio: 1 / 0.65;
-  transition: flex-basis 0.3s ease;
+  transition: flex 0.3s ease;
 }
 
 .catalog-image img {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -679,7 +679,7 @@ footer {
   border: 1px solid #fff;
   border-radius: 12px;
   height: calc((100vw - 80px) * 0.325);
-  transition: flex-basis 0.3s ease;
+  transition: flex-basis 0.6s ease;
 }
 
 .catalog-item img {
@@ -690,7 +690,7 @@ footer {
   height: 100%;
   object-fit: cover;
   z-index: 0;
-  transition: transform 0.3s ease;
+  transition: transform 0.6s ease;
 }
 
 .catalog-item:hover img {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -678,7 +678,7 @@ footer {
   overflow: hidden;
   border: 1px solid #fff;
   border-radius: 12px;
-  aspect-ratio: 1 / 0.65;
+  height: calc((100vw - 80px) * 0.325);
   transition: flex-basis 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- restyle catalog grid with side padding and rounded card corners
- animate tiles to widen on hover while adjacent tile narrows
- gently scale product images during hover

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baec97722c832cb23afb7afd21cc81