### PR TITLE
feat: switch to Michroma font globally

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>О нас</title>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Michroma&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/styles.css" />
   </head>
   <body>

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,3 +1,35 @@
+/* === Global font: Michroma everywhere === */
+html, body {
+  font-family: "Michroma", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  font-weight: 400;                 /* у Michroma один базовый вес — оставляем 400 */
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+
+/* Небольшая разрядка для заголовков/навигации в духе wordmark */
+h1, h2, h3, h4, h5, h6,
+.navbar a, .btn, .phone-btn, .request-btn,
+.logo-text, .logo-name {
+  letter-spacing: 0.06em;           /* аккуратно, чтобы абзацы не «расползались» */
+  text-transform: none;             /* по желанию: можно uppercase */
+}
+
+/* Для логотипа можно шире, если нужно «как в лого» */
+.logo-name {
+  letter-spacing: 0.22em;           /* как в варианте B */
+  text-transform: uppercase;        /* подчеркнуть «логотипность» */
+}
+
+/* Опционально: плотнее абзацы и шире числа */
+p, li {
+  letter-spacing: 0;
+}
+
+.kpi, .stat {
+  letter-spacing: 0.08em;
+}
+
 html {
   scroll-behavior: smooth;
 }
@@ -11,7 +43,6 @@ html {
 
 body {
   margin: 0;
-  font-family: 'Montserrat', sans-serif;
   background-color: var(--color-bg);
   color: var(--color-text);
   line-height: 1.5;

--- a/catalog.html
+++ b/catalog.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Каталог</title>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Michroma&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/styles.css" />
   </head>
   <body>

--- a/contacts.html
+++ b/contacts.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Контакты</title>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Michroma&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/styles.css" />
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>iStore Landing</title>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Michroma&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
     <link rel="stylesheet" href="assets/styles.css" />
     <link

--- a/item1.html
+++ b/item1.html
@@ -4,12 +4,13 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Машина чешуирования</title>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Michroma&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/styles.css" />
     <style>
       body {
         margin: 0;
-        font-family: 'Montserrat', sans-serif;
         display: flex;
         flex-direction: column;
         height: 100vh;

--- a/item1.html
+++ b/item1.html
@@ -127,10 +127,6 @@
       <div class="logo">
         <img src="assets/images/logo.png" />
         </svg>
-        <div class="logo-text">
-          <span class="logo-name">GIR ROS</span>
-          <!-- <small class="logo-tagline">ПРОМЫШЛЕННОЕ ОБОРУДОВАНИЕ</small> -->
-        </div>
       </div>
       <button class="hamburger" aria-label="Меню">&#9776;</button>
       <ul class="navbar">
@@ -140,6 +136,10 @@
         <li><a href="index.html#reviews">Отзывы</a></li>
         <li><a href="index.html#contacts">Контакты</a></li>
       </ul>
+        <div class="logo-text">
+          <span class="logo-name">GIR ROS</span>
+          <!-- <small class="logo-tagline">ПРОМЫШЛЕННОЕ ОБОРУДОВАНИЕ</small> -->
+        </div>
       <div class="navbar-right">
         <a href="https://t.me/" class="icon-btn" target="_blank" aria-label="Telegram">
           <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">

--- a/reviews.html
+++ b/reviews.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Отзывы</title>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&display=swap" rel="stylesheet" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Michroma&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="assets/styles.css" />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- load Google Michroma font across all pages and remove old Montserrat links
- add global font and letter-spacing rules in CSS with minor logo spacing tweaks
- drop obsolete font overrides so elements inherit the new site-wide typeface

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c098274278832c8c6e5547f832d6c0