### PR TITLE
Refine navbar layout with centered brand

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,32 +11,19 @@
   </head>
   <body>
     <header>
-      <div class="logo">
-        <svg
-          class="apple-icon"
-          viewBox="0 0 24 24"
-          width="24"
-          height="24"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            d="M16.365 1.43c-.92.055-2 .64-2.65 1.39-.57.65-1.07 1.66-.88 2.63h.05c.95 0 2.06-.6 2.71-1.35.58-.66 1.02-1.67.77-2.67zM21.8 16.6c-.73 1.68-1.6 3.36-2.8 4.77-1.13 1.31-2.5 2.63-4.28 2.63-1.66 0-2.1-.86-3.9-.86-1.83 0-2.33.84-3.87.86-1.78 0-3.23-1.73-4.36-3.04C.83 18.9-.13 15.6.3 12.53c.36-2.46 1.8-4.53 3.6-5.77a5.54 5.54 0 012.95-.95c1.63 0 3.17 1.12 3.9 1.12.72 0 2.13-1.37 3.95-1.17.67.03 2.55.27 3.76 2.03-3.2 1.73-2.68 6.22.49 7.02z"
-          />
-        </svg>
-        <div class="logo-text">
-          <span class="logo-name">iStore</span>
-          <small class="logo-tagline">МАГАЗИН ТЕХНИКИ APPLE</small>
+      <div class="nav-left">
+        <div class="logo">
+          <img src="assets/images/logo.png" alt="GIR ROS logo" />
         </div>
+        <ul class="navbar">
+          <li><a href="index.html">Главная</a></li>
+          <li><a href="catalog.html">Каталог</a></li>
+          <li><a href="about.html">Преимущества</a></li>
+          <li><a href="reviews.html">Отзывы</a></li>
+          <li><a href="contacts.html">Контакты</a></li>
+        </ul>
       </div>
-      <button class="hamburger" aria-label="Меню">&#9776;</button>
-      <ul class="navbar">
-        <li><a href="index.html">Главная</a></li>
-        <li><a href="catalog.html">Каталог</a></li>
-        <li><a href="about.html">Преимущества</a></li>
-        <li><a href="reviews.html">Отзывы</a></li>
-        <li><a href="contacts.html">Контакты</a></li>
-      </ul>
+      <div class="company-name">GIR ROS</div>
       <div class="navbar-right">
         <a href="https://t.me/" class="icon-btn" target="_blank" aria-label="Telegram">
           <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
@@ -56,6 +43,7 @@
         <a href="tel:+78000000000" class="phone-btn">+7 (800) 000-00-00</a>
         <button class="request-btn">Оставить заявку</button>
       </div>
+      <button class="hamburger" aria-label="Меню">&#9776;</button>
     </header>
 
     <section class="section-background">

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -82,13 +82,30 @@ h3 {
 header {
   background-color: #000;
   color: #fff;
-  padding: 10px 40px;
+  padding: 20px 40px;
   position: sticky;
   top: 0;
   z-index: 1000;
   display: flex;
   justify-content: space-between;
   align-items: center;
+  border-bottom: 1px solid #ccc;
+}
+
+.nav-left {
+  display: flex;
+  align-items: center;
+  gap: 40px;
+}
+
+.company-name {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  font-weight: 700;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: #fff;
 }
 
 .logo {
@@ -454,6 +471,17 @@ footer {
     align-items: flex-start;
   }
 
+  .nav-left {
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .company-name {
+    position: static;
+    transform: none;
+    margin-top: 10px;
+  }
+
   .hamburger {
     display: block;
     background: none;
@@ -764,11 +792,7 @@ footer {
 }
 
 .logo img {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 50px;
-  height: 50px;
-  object-fit: cover;
-  z-index: 0;
+  width: 60px;
+  height: 60px;
+  object-fit: contain;
 }

--- a/catalog.html
+++ b/catalog.html
@@ -11,32 +11,19 @@
   </head>
   <body>
     <header>
-      <div class="logo">
-        <svg
-          class="apple-icon"
-          viewBox="0 0 24 24"
-          width="24"
-          height="24"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            d="M16.365 1.43c-.92.055-2 .64-2.65 1.39-.57.65-1.07 1.66-.88 2.63h.05c.95 0 2.06-.6 2.71-1.35.58-.66 1.02-1.67.77-2.67zM21.8 16.6c-.73 1.68-1.6 3.36-2.8 4.77-1.13 1.31-2.5 2.63-4.28 2.63-1.66 0-2.1-.86-3.9-.86-1.83 0-2.33.84-3.87.86-1.78 0-3.23-1.73-4.36-3.04C.83 18.9-.13 15.6.3 12.53c.36-2.46 1.8-4.53 3.6-5.77a5.54 5.54 0 012.95-.95c1.63 0 3.17 1.12 3.9 1.12.72 0 2.13-1.37 3.95-1.17.67.03 2.55.27 3.76 2.03-3.2 1.73-2.68 6.22.49 7.02z"
-          />
-        </svg>
-        <div class="logo-text">
-          <span class="logo-name">iStore</span>
-          <small class="logo-tagline">МАГАЗИН ТЕХНИКИ APPLE</small>
+      <div class="nav-left">
+        <div class="logo">
+          <img src="assets/images/logo.png" alt="GIR ROS logo" />
         </div>
+        <ul class="navbar">
+          <li><a href="index.html">Главная</a></li>
+          <li><a href="catalog.html">Каталог</a></li>
+          <li><a href="about.html">Преимущества</a></li>
+          <li><a href="reviews.html">Отзывы</a></li>
+          <li><a href="contacts.html">Контакты</a></li>
+        </ul>
       </div>
-      <button class="hamburger" aria-label="Меню">&#9776;</button>
-      <ul class="navbar">
-        <li><a href="index.html">Главная</a></li>
-        <li><a href="catalog.html">Каталог</a></li>
-        <li><a href="about.html">Преимущества</a></li>
-        <li><a href="reviews.html">Отзывы</a></li>
-        <li><a href="contacts.html">Контакты</a></li>
-      </ul>
+      <div class="company-name">GIR ROS</div>
       <div class="navbar-right">
         <a href="https://t.me/" class="icon-btn" target="_blank" aria-label="Telegram">
           <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
@@ -56,6 +43,7 @@
         <a href="tel:+78000000000" class="phone-btn">+7 (800) 000-00-00</a>
         <button class="request-btn">Оставить заявку</button>
       </div>
+      <button class="hamburger" aria-label="Меню">&#9776;</button>
     </header>
 
       <section id="catalog" class="catalog-section">

--- a/contacts.html
+++ b/contacts.html
@@ -11,32 +11,19 @@
   </head>
   <body>
     <header>
-      <div class="logo">
-        <svg
-          class="apple-icon"
-          viewBox="0 0 24 24"
-          width="24"
-          height="24"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            d="M16.365 1.43c-.92.055-2 .64-2.65 1.39-.57.65-1.07 1.66-.88 2.63h.05c.95 0 2.06-.6 2.71-1.35.58-.66 1.02-1.67.77-2.67zM21.8 16.6c-.73 1.68-1.6 3.36-2.8 4.77-1.13 1.31-2.5 2.63-4.28 2.63-1.66 0-2.1-.86-3.9-.86-1.83 0-2.33.84-3.87.86-1.78 0-3.23-1.73-4.36-3.04C.83 18.9-.13 15.6.3 12.53c.36-2.46 1.8-4.53 3.6-5.77a5.54 5.54 0 012.95-.95c1.63 0 3.17 1.12 3.9 1.12.72 0 2.13-1.37 3.95-1.17.67.03 2.55.27 3.76 2.03-3.2 1.73-2.68 6.22.49 7.02z"
-          />
-        </svg>
-        <div class="logo-text">
-          <span class="logo-name">iStore</span>
-          <small class="logo-tagline">МАГАЗИН ТЕХНИКИ APPLE</small>
+      <div class="nav-left">
+        <div class="logo">
+          <img src="assets/images/logo.png" alt="GIR ROS logo" />
         </div>
+        <ul class="navbar">
+          <li><a href="index.html">Главная</a></li>
+          <li><a href="catalog.html">Каталог</a></li>
+          <li><a href="about.html">Преимущества</a></li>
+          <li><a href="reviews.html">Отзывы</a></li>
+          <li><a href="contacts.html">Контакты</a></li>
+        </ul>
       </div>
-      <button class="hamburger" aria-label="Меню">&#9776;</button>
-      <ul class="navbar">
-        <li><a href="index.html">Главная</a></li>
-        <li><a href="catalog.html">Каталог</a></li>
-        <li><a href="about.html">Преимущества</a></li>
-        <li><a href="reviews.html">Отзывы</a></li>
-        <li><a href="contacts.html">Контакты</a></li>
-      </ul>
+      <div class="company-name">GIR ROS</div>
       <div class="navbar-right">
         <a href="https://t.me/" class="icon-btn" target="_blank" aria-label="Telegram">
           <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
@@ -56,6 +43,7 @@
         <a href="tel:+78000000000" class="phone-btn">+7 (800) 000-00-00</a>
         <button class="request-btn">Оставить заявку</button>
       </div>
+      <button class="hamburger" aria-label="Меню">&#9776;</button>
     </header>
 
     <section class="section-background">

--- a/index.html
+++ b/index.html
@@ -16,22 +16,19 @@
   </head>
   <body>
     <header>
-      <div class="logo">
-        <img src="assets/images/logo.png" />
-        </svg>
-        <div class="logo-text">
-          <span class="logo-name">GIR ROS</span>
-          <!-- <small class="logo-tagline">ПРОМЫШЛЕННОЕ ОБОРУДОВАНИЕ</small> -->
+      <div class="nav-left">
+        <div class="logo">
+          <img src="assets/images/logo.png" alt="GIR ROS logo" />
         </div>
+        <ul class="navbar">
+          <li><a href="#home">Главная</a></li>
+          <li><a href="#catalog">Каталог</a></li>
+          <li><a href="#features">Преимущества</a></li>
+          <li><a href="#reviews">Отзывы</a></li>
+          <li><a href="#contacts">Контакты</a></li>
+        </ul>
       </div>
-      <button class="hamburger" aria-label="Меню">&#9776;</button>
-      <ul class="navbar">
-        <li><a href="#home">Главная</a></li>
-        <li><a href="#catalog">Каталог</a></li>
-        <li><a href="#features">Преимущества</a></li>
-        <li><a href="#reviews">Отзывы</a></li>
-        <li><a href="#contacts">Контакты</a></li>
-      </ul>
+      <div class="company-name">GIR ROS</div>
       <div class="navbar-right">
         <a href="https://t.me/" class="icon-btn" target="_blank" aria-label="Telegram">
           <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
@@ -51,6 +48,7 @@
         <a href="tel:+78000000000" class="phone-btn">+7 (800) 000-00-00</a>
         <button class="request-btn">Оставить заявку</button>
       </div>
+      <button class="hamburger" aria-label="Меню">&#9776;</button>
     </header>
 
     <section id="home" class="hero">

--- a/item1.html
+++ b/item1.html
@@ -124,22 +124,19 @@
   </head>
   <body class="item-page">
     <header>
-      <div class="logo">
-        <img src="assets/images/logo.png" />
-        </svg>
-        <div class="logo-text">
-          <span class="logo-name">GIR ROS</span>
-          <!-- <small class="logo-tagline">ПРОМЫШЛЕННОЕ ОБОРУДОВАНИЕ</small> -->
+      <div class="nav-left">
+        <div class="logo">
+          <img src="assets/images/logo.png" alt="GIR ROS logo" />
         </div>
+        <ul class="navbar">
+          <li><a href="index.html#home">Главная</a></li>
+          <li><a href="index.html#catalog">Каталог</a></li>
+          <li><a href="index.html#features">Преимущества</a></li>
+          <li><a href="index.html#reviews">Отзывы</a></li>
+          <li><a href="index.html#contacts">Контакты</a></li>
+        </ul>
       </div>
-      <button class="hamburger" aria-label="Меню">&#9776;</button>
-      <ul class="navbar">
-        <li><a href="index.html#home">Главная</a></li>
-        <li><a href="index.html#catalog">Каталог</a></li>
-        <li><a href="index.html#features">Преимущества</a></li>
-        <li><a href="index.html#reviews">Отзывы</a></li>
-        <li><a href="index.html#contacts">Контакты</a></li>
-      </ul>
+      <div class="company-name">GIR ROS</div>
       <div class="navbar-right">
         <a href="https://t.me/" class="icon-btn" target="_blank" aria-label="Telegram">
           <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
@@ -159,6 +156,7 @@
         <a href="tel:+78000000000" class="phone-btn">+7 (800) 000-00-00</a>
         <button class="request-btn">Оставить заявку</button>
       </div>
+      <button class="hamburger" aria-label="Меню">&#9776;</button>
     </header>
     <div class="action-buttons">
       <button id="homeBtn">на главную</button>

--- a/reviews.html
+++ b/reviews.html
@@ -11,32 +11,19 @@
   </head>
   <body>
     <header>
-      <div class="logo">
-        <svg
-          class="apple-icon"
-          viewBox="0 0 24 24"
-          width="24"
-          height="24"
-          fill="currentColor"
-          aria-hidden="true"
-        >
-          <path
-            d="M16.365 1.43c-.92.055-2 .64-2.65 1.39-.57.65-1.07 1.66-.88 2.63h.05c.95 0 2.06-.6 2.71-1.35.58-.66 1.02-1.67.77-2.67zM21.8 16.6c-.73 1.68-1.6 3.36-2.8 4.77-1.13 1.31-2.5 2.63-4.28 2.63-1.66 0-2.1-.86-3.9-.86-1.83 0-2.33.84-3.87.86-1.78 0-3.23-1.73-4.36-3.04C.83 18.9-.13 15.6.3 12.53c.36-2.46 1.8-4.53 3.6-5.77a5.54 5.54 0 012.95-.95c1.63 0 3.17 1.12 3.9 1.12.72 0 2.13-1.37 3.95-1.17.67.03 2.55.27 3.76 2.03-3.2 1.73-2.68 6.22.49 7.02z"
-          />
-        </svg>
-        <div class="logo-text">
-          <span class="logo-name">iStore</span>
-          <small class="logo-tagline">МАГАЗИН ТЕХНИКИ APPLE</small>
+      <div class="nav-left">
+        <div class="logo">
+          <img src="assets/images/logo.png" alt="GIR ROS logo" />
         </div>
+        <ul class="navbar">
+          <li><a href="index.html">Главная</a></li>
+          <li><a href="catalog.html">Каталог</a></li>
+          <li><a href="about.html">Преимущества</a></li>
+          <li><a href="reviews.html">Отзывы</a></li>
+          <li><a href="contacts.html">Контакты</a></li>
+        </ul>
       </div>
-      <button class="hamburger" aria-label="Меню">&#9776;</button>
-      <ul class="navbar">
-        <li><a href="index.html">Главная</a></li>
-        <li><a href="catalog.html">Каталог</a></li>
-        <li><a href="about.html">Преимущества</a></li>
-        <li><a href="reviews.html">Отзывы</a></li>
-        <li><a href="contacts.html">Контакты</a></li>
-      </ul>
+      <div class="company-name">GIR ROS</div>
       <div class="navbar-right">
         <a href="https://t.me/" class="icon-btn" target="_blank" aria-label="Telegram">
           <svg viewBox="0 0 24 24" fill="currentColor" width="20" height="20">
@@ -56,6 +43,7 @@
         <a href="tel:+78000000000" class="phone-btn">+7 (800) 000-00-00</a>
         <button class="request-btn">Оставить заявку</button>
       </div>
+      <button class="hamburger" aria-label="Меню">&#9776;</button>
     </header>
 
     <section>


### PR DESCRIPTION
## Summary
- Rearranged navigation to show logo on the left, menu links nearby, and company name centered
- Increased navbar height and added a subtle bottom border
- Updated all pages to use the new header layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c11fb83b24832c852834655364140c