### PR TITLE
Reduce spacing between item image and title

### DIFF
--- a/item1.html
+++ b/item1.html
@@ -43,7 +43,8 @@
       }
       .item-title {
         text-align: center;
-        padding: 20px 0;
+        margin: 10px 0;
+        padding: 0;
         font-size: 24px;
       }
       /* Inverted navbar colors */


### PR DESCRIPTION
## Summary
- tighten spacing between item image and title on item page by adjusting `.item-title` margins and padding

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c30cc49f24832c993f056343066765