### PR TITLE
Position item title closer to product image

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -114,6 +114,7 @@ header .logo-text {
 
 .logo-name {
   font-weight: 700;
+  font-size: 24px;
 }
 
 .logo-tagline {

--- a/item1.html
+++ b/item1.html
@@ -16,9 +16,7 @@
         height: 100vh;
       }
       .image-wrapper {
-        flex: 1;
         display: flex;
-        align-items: center;
         justify-content: center;
         position: relative;
         width: 100%;
@@ -43,7 +41,8 @@
       }
       .item-title {
         text-align: center;
-        padding: 20px 0;
+        margin: 0;
+        padding: 0 0 20px;
         font-size: 24px;
       }
       /* Inverted navbar colors */

--- a/item1.html
+++ b/item1.html
@@ -16,7 +16,9 @@
         height: 100vh;
       }
       .image-wrapper {
+        flex: 1;
         display: flex;
+        align-items: center;
         justify-content: center;
         position: relative;
         width: 100%;
@@ -41,8 +43,8 @@
       }
       .item-title {
         text-align: center;
-        margin: 0;
-        padding: 0 0 20px;
+        margin: 10px 0;
+        padding: 0;
         font-size: 24px;
       }
       /* Inverted navbar colors */

--- a/item1.html
+++ b/item1.html
@@ -16,9 +16,7 @@
         height: 100vh;
       }
       .image-wrapper {
-        flex: 1;
         display: flex;
-        align-items: center;
         justify-content: center;
         position: relative;
         width: 100%;
@@ -43,8 +41,8 @@
       }
       .item-title {
         text-align: center;
-        margin: 10px 0;
-        padding: 0;
+        margin: 0;
+        padding: 0 0 20px;
         font-size: 24px;
       }
       /* Inverted navbar colors */
@@ -113,7 +111,7 @@
     <div id="image-wrapper" class="image-wrapper">
       <img src="assets/images/item1_pic1.png" alt="item1_pic1" />
     </div>
-    <h2 class="item-title">Машина чешуирования</h2>
+    <h2 class="item-title">МАШИНА ЧЕШУИРОВАНИЯ</h2>
     <div id="request-modal" class="modal">
       <div class="modal-content">
         <button class="close-modal">&times;</button>


### PR DESCRIPTION
## Summary
- Remove extra vertical flex space from product image wrapper
- Trim default spacing so product title sits flush below image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c30fc5caa4832c89d3f98915ad960f