### PR TITLE
Add main section navigation on item page

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -30,6 +30,17 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    const itemNavLinks = document.querySelectorAll('.item-nav-btn[href^="#"]');
+    itemNavLinks.forEach(link => {
+        link.addEventListener('click', e => {
+            e.preventDefault();
+            const target = document.querySelector(link.getAttribute('href'));
+            if (target) {
+                target.scrollIntoView({ behavior: 'smooth' });
+            }
+        });
+    });
+
     const observer = new IntersectionObserver((entries, obs) => {
         entries.forEach(entry => {
             if (entry.isIntersecting) {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -248,7 +248,11 @@ header .logo-text {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 40px;
+  margin-top: 40px;
+}
+
+.item-page section {
+  scroll-margin-top: 80px;
 }
 
 .item-page .main-layout {
@@ -260,12 +264,12 @@ header .logo-text {
 
 .item-page .item-nav {
   position: absolute;
-  left: 100px;
-  top: 100px;
-  transform: none;
+  left: 40px;
+  top: 0;
   display: flex;
   flex-direction: column;
-  gap: 40px;
+  gap: 20px;
+  z-index: 1;
 }
 
 .item-page .item-nav-btn {
@@ -280,13 +284,14 @@ header .logo-text {
   font-family: "Arial Narrow", Arial, sans-serif;
   font-size: 20px;
   cursor: pointer;
-  transition: background 0.3s, color 0.3s;
+  transition: background 0.3s, color 0.3s, border-color 0.3s;
 }
 
 .item-page .item-nav-btn:hover,
 .item-page .item-nav-btn:active {
   background: #000;
   color: #fff;
+  border-color: #fff;
 }
 
 .item-page .image-wrapper::before {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -260,12 +260,12 @@ header .logo-text {
 
 .item-page .item-nav {
   position: absolute;
-  left: 100px;
-  top: 100px;
+  left: 40px;
+  top: 40px;
   transform: none;
   display: flex;
   flex-direction: column;
-  gap: 40px;
+  gap: 20px;
 }
 
 .item-page .item-nav-btn {
@@ -277,6 +277,7 @@ header .logo-text {
   color: #000;
   text-align: left;
   font-family: "Arial Narrow", Arial, sans-serif;
+  font-size: 20px;
 }
 
 .item-page .item-nav-btn:hover {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -260,28 +260,33 @@ header .logo-text {
 
 .item-page .item-nav {
   position: absolute;
-  left: 40px;
-  top: 40px;
+  left: 100px;
+  top: 100px;
   transform: none;
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 40px;
 }
 
 .item-page .item-nav-btn {
-  display: block;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 10px 20px;
   border: 1px solid #000;
   border-radius: 8px;
   background: #fff;
   color: #000;
-  text-align: left;
   font-family: "Arial Narrow", Arial, sans-serif;
   font-size: 20px;
+  cursor: pointer;
+  transition: background 0.3s, color 0.3s;
 }
 
-.item-page .item-nav-btn:hover {
-  background: #f5f5f5;
+.item-page .item-nav-btn:hover,
+.item-page .item-nav-btn:active {
+  background: #000;
+  color: #fff;
 }
 
 .item-page .image-wrapper::before {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -260,12 +260,12 @@ header .logo-text {
 
 .item-page .item-nav {
   position: absolute;
-  left: 20px;
-  top: 50%;
-  transform: translateY(-50%);
+  left: 100px;
+  top: 100px;
+  transform: none;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 40px;
 }
 
 .item-page .item-nav-btn {
@@ -276,6 +276,7 @@ header .logo-text {
   background: #fff;
   color: #000;
   text-align: left;
+  font-family: "Arial Narrow", Arial, sans-serif;
 }
 
 .item-page .item-nav-btn:hover {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -244,6 +244,44 @@ header .logo-text {
   overflow: hidden;
 }
 
+.item-page .main-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding-top: 40px;
+}
+
+.item-page .main-layout {
+  position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.item-page .item-nav {
+  position: absolute;
+  left: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.item-page .item-nav-btn {
+  display: block;
+  padding: 10px 20px;
+  border: 1px solid #000;
+  border-radius: 8px;
+  background: #fff;
+  color: #000;
+  text-align: left;
+}
+
+.item-page .item-nav-btn:hover {
+  background: #f5f5f5;
+}
+
 .item-page .image-wrapper::before {
   content: "";
   position: absolute;

--- a/item.html
+++ b/item.html
@@ -60,12 +60,15 @@
     </section>
     <section id="characteristics">
       <h2>Характеристики</h2>
+      <p>Здесь будут технические характеристики товара.</p>
     </section>
     <section id="configurator">
       <h2>Конфигуратор</h2>
+      <p>Подберите конфигурацию изделия.</p>
     </section>
     <section id="model3d">
       <h2>3D-модель</h2>
+      <p>Интерактивная 3D-модель появится здесь.</p>
     </section>
     <div id="request-modal" class="modal">
       <div class="modal-content">

--- a/item.html
+++ b/item.html
@@ -45,10 +45,28 @@
         <button class="request-btn">Оставить заявку</button>
       </div>
     </header>
-    <div id="image-wrapper" class="image-wrapper">
-      <img src="" alt="" />
-    </div>
-    <h2 class="item-title"></h2>
+    <section id="main" class="main-section">
+      <div class="main-layout">
+        <nav class="item-nav">
+          <a href="#characteristics" class="item-nav-btn">Характеристики</a>
+          <a href="#configurator" class="item-nav-btn">Конфигуратор</a>
+          <a href="#model3d" class="item-nav-btn">3D-модель</a>
+        </nav>
+        <div id="image-wrapper" class="image-wrapper">
+          <img src="" alt="" />
+        </div>
+      </div>
+      <h2 class="item-title"></h2>
+    </section>
+    <section id="characteristics">
+      <h2>Характеристики</h2>
+    </section>
+    <section id="configurator">
+      <h2>Конфигуратор</h2>
+    </section>
+    <section id="model3d">
+      <h2>3D-модель</h2>
+    </section>
     <div id="request-modal" class="modal">
       <div class="modal-content">
         <button class="close-modal">&times;</button>


### PR DESCRIPTION
## Summary
- Introduce `main` section on item page with image and title
- Add left-side navigation buttons linking to Characteristics, Configurator, and 3D model sections
- Style new navigation buttons and layout

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68c3ab1df788832cba871b8f321b5b1f