### PR TITLE
Add item characteristics section

### DIFF
--- a/assets/items.js
+++ b/assets/items.js
@@ -1,27 +1,57 @@
 const ITEMS = {
   item1: {
     title: 'МАШИНА ЧЕШУИРОВАНИЯ',
-    image: 'assets/images/item1_pic1.png'
+    image: 'assets/images/item1_pic1.png',
+    characteristics: [
+      { value: '4,1 с', description: 'Разгон 0–100 км/ч' },
+      { value: '290 кВт / 394 л.с.', description: 'Мощность' },
+      { value: '294 км/ч', description: 'Максимальная скорость' }
+    ]
   },
   item2: {
     title: 'БАРАБАННОЕ ОБОРУДОВАНИЕ',
-    image: 'assets/images/item2_pic1.png'
+    image: 'assets/images/item2_pic1.png',
+    characteristics: [
+      { value: '4,1 с', description: 'Разгон 0–100 км/ч' },
+      { value: '290 кВт / 394 л.с.', description: 'Мощность' },
+      { value: '294 км/ч', description: 'Максимальная скорость' }
+    ]
   },
   item3: {
     title: 'КОМПРЕССОРНОЕ ОБОРУДОВАНИЕ',
-    image: 'assets/images/item3.png'
+    image: 'assets/images/item3.png',
+    characteristics: [
+      { value: '4,1 с', description: 'Разгон 0–100 км/ч' },
+      { value: '290 кВт / 394 л.с.', description: 'Мощность' },
+      { value: '294 км/ч', description: 'Максимальная скорость' }
+    ]
   },
   item4: {
     title: 'ЁМКОСТИ И РЕЗЕРВУАРЫ',
-    image: 'assets/images/item4.png'
+    image: 'assets/images/item4.png',
+    characteristics: [
+      { value: '4,1 с', description: 'Разгон 0–100 км/ч' },
+      { value: '290 кВт / 394 л.с.', description: 'Мощность' },
+      { value: '294 км/ч', description: 'Максимальная скорость' }
+    ]
   },
   item5: {
     title: 'ТЕПЛООБМЕННОЕ ОБОРУДОВАНИЕ',
-    image: 'assets/images/airpods.png'
+    image: 'assets/images/airpods.png',
+    characteristics: [
+      { value: '4,1 с', description: 'Разгон 0–100 км/ч' },
+      { value: '290 кВт / 394 л.с.', description: 'Мощность' },
+      { value: '294 км/ч', description: 'Максимальная скорость' }
+    ]
   },
   item6: {
     title: 'iMac 24″',
-    image: 'assets/images/mac.png'
+    image: 'assets/images/mac.png',
+    characteristics: [
+      { value: '4,1 с', description: 'Разгон 0–100 км/ч' },
+      { value: '290 кВт / 394 л.с.', description: 'Мощность' },
+      { value: '294 км/ч', description: 'Максимальная скорость' }
+    ]
   }
 };
 

--- a/assets/script.js
+++ b/assets/script.js
@@ -112,7 +112,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const params = new URLSearchParams(window.location.search);
         const itemId = params.get('id');
         if (itemId && ITEMS[itemId]) {
-            const { title, image } = ITEMS[itemId];
+            const { title, image, characteristics } = ITEMS[itemId];
             const titleEl = document.querySelector('.item-title');
             const imageEl = document.querySelector('#image-wrapper img');
             if (titleEl) {
@@ -122,6 +122,26 @@ document.addEventListener('DOMContentLoaded', () => {
             if (imageEl) {
                 imageEl.src = image;
                 imageEl.alt = itemId;
+            }
+
+            const charImgEl = document.querySelector('#characteristics img');
+            if (charImgEl) {
+                let secondaryImage = image.replace(/_pic1(\.[a-z]+)$/i, '_pic2$1');
+                if (secondaryImage === image) {
+                    secondaryImage = image.replace(/(\.[a-z]+)$/i, '_pic2$1');
+                }
+                charImgEl.src = secondaryImage;
+                charImgEl.alt = itemId + ' details';
+            }
+
+            const statsContainer = document.querySelector('.characteristics-stats');
+            if (statsContainer && Array.isArray(characteristics)) {
+                characteristics.forEach(({ value, description }) => {
+                    const stat = document.createElement('div');
+                    stat.className = 'stat-item';
+                    stat.innerHTML = `\n                        <div class="stat-value">${value}</div>\n                        <div class="stat-desc">${description}</div>\n                    `;
+                    statsContainer.appendChild(stat);
+                });
             }
         }
     }

--- a/assets/script.js
+++ b/assets/script.js
@@ -107,9 +107,9 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const ODOMETER_DEFAULTS = {
-        duration: 2000,
-        easing: 'cubic-bezier(0.25, 0.1, 0.25, 1)',
-        loops: 1
+        duration: 5000,
+        easing: 'cubic-bezier(0.33, 1, 0.68, 1)',
+        loops: 2
     };
 
     function prepareOdometer(el, options = {}) {
@@ -153,6 +153,10 @@ document.addEventListener('DOMContentLoaded', () => {
         requestAnimationFrame(() => {
             digits.forEach(({ seq, offset }) => {
                 seq.style.transform = `translateY(-${offset * 100}%)`;
+                seq.addEventListener('transitionend', () => {
+                    const wrapper = seq.parentElement;
+                    wrapper.textContent = offset % 10;
+                }, { once: true });
             });
         });
     }

--- a/assets/script.js
+++ b/assets/script.js
@@ -107,6 +107,37 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
+    function animateValue(el, duration = 1500) {
+        const target = el.dataset.value;
+        const numbers = target.match(/\d+[.,]?\d*/g);
+        if (!numbers) return;
+        const parts = target.split(/\d+[.,]?\d*/g);
+        const targets = numbers.map(n => parseFloat(n.replace(',', '.')));
+        const decimals = numbers.map(n => (n.includes('.') || n.includes(',')) ? (n.split(/[.,]/)[1] || '').length : 0);
+        const startTime = performance.now();
+
+        function update(now) {
+            const progress = Math.min((now - startTime) / duration, 1);
+            let text = '';
+            for (let i = 0; i < targets.length; i++) {
+                let val = targets[i] * progress;
+                let str = decimals[i] ? val.toFixed(decimals[i]) : Math.round(val).toString();
+                if (numbers[i].includes(',')) {
+                    str = str.replace('.', ',');
+                }
+                text += parts[i] + str;
+            }
+            text += parts[parts.length - 1];
+            el.textContent = text;
+            if (progress < 1) {
+                requestAnimationFrame(update);
+            }
+        }
+
+        el.textContent = parts[0] + '0' + parts.slice(1).join('');
+        requestAnimationFrame(update);
+    }
+
     // Populate item page from ITEMS data if present
     if (document.body.classList.contains('item-page') && typeof ITEMS !== 'undefined') {
         const params = new URLSearchParams(window.location.search);
@@ -139,9 +170,20 @@ document.addEventListener('DOMContentLoaded', () => {
                 characteristics.forEach(({ value, description }) => {
                     const stat = document.createElement('div');
                     stat.className = 'stat-item';
-                    stat.innerHTML = `\n                        <div class="stat-value">${value}</div>\n                        <div class="stat-desc">${description}</div>\n                    `;
+                    stat.innerHTML = `\n                        <div class="stat-value" data-value="${value}"></div>\n                        <div class="stat-desc">${description}</div>\n                    `;
                     statsContainer.appendChild(stat);
                 });
+
+                const statValues = statsContainer.querySelectorAll('.stat-value');
+                const statsObserver = new IntersectionObserver((entries, obs) => {
+                    entries.forEach(entry => {
+                        if (entry.isIntersecting) {
+                            animateValue(entry.target);
+                            obs.unobserve(entry.target);
+                        }
+                    });
+                }, { threshold: 0.5 });
+                statValues.forEach(el => statsObserver.observe(el));
             }
         }
     }

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,5 +1,4 @@
 // Placeholder script for interactive features
-console.log('Store loaded');
 
 document.addEventListener('DOMContentLoaded', () => {
     const requestBtn = document.querySelector('.request-btn');
@@ -107,35 +106,55 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     });
 
-    function animateValue(el, duration = 1500) {
-        const target = el.dataset.value;
-        const numbers = target.match(/\d+[.,]?\d*/g);
-        if (!numbers) return;
-        const parts = target.split(/\d+[.,]?\d*/g);
-        const targets = numbers.map(n => parseFloat(n.replace(',', '.')));
-        const decimals = numbers.map(n => (n.includes('.') || n.includes(',')) ? (n.split(/[.,]/)[1] || '').length : 0);
-        const startTime = performance.now();
+    const ODOMETER_DEFAULTS = {
+        duration: 2000,
+        easing: 'cubic-bezier(0.25, 0.1, 0.25, 1)',
+        loops: 1
+    };
 
-        function update(now) {
-            const progress = Math.min((now - startTime) / duration, 1);
-            let text = '';
-            for (let i = 0; i < targets.length; i++) {
-                let val = targets[i] * progress;
-                let str = decimals[i] ? val.toFixed(decimals[i]) : Math.round(val).toString();
-                if (numbers[i].includes(',')) {
-                    str = str.replace('.', ',');
+    function prepareOdometer(el, options = {}) {
+        const { duration, easing, loops } = { ...ODOMETER_DEFAULTS, ...options };
+        const value = el.dataset.value || '';
+        const fragments = document.createDocumentFragment();
+        const digits = [];
+
+        for (const ch of value) {
+            if (/\d/.test(ch)) {
+                const digitWrapper = document.createElement('span');
+                digitWrapper.className = 'odometer-digit';
+                const seq = document.createElement('span');
+                seq.className = 'digit-sequence';
+                const total = loops * 10 + parseInt(ch, 10) + 1;
+                for (let i = 0; i < total; i++) {
+                    const d = document.createElement('span');
+                    d.textContent = i % 10;
+                    seq.appendChild(d);
                 }
-                text += parts[i] + str;
-            }
-            text += parts[parts.length - 1];
-            el.textContent = text;
-            if (progress < 1) {
-                requestAnimationFrame(update);
+                digitWrapper.appendChild(seq);
+                fragments.appendChild(digitWrapper);
+                digits.push({ seq, offset: total - 1 });
+            } else {
+                const span = document.createElement('span');
+                span.textContent = ch;
+                fragments.appendChild(span);
             }
         }
 
-        el.textContent = parts[0] + '0' + parts.slice(1).join('');
-        requestAnimationFrame(update);
+        el.innerHTML = '';
+        el.appendChild(fragments);
+        el.style.setProperty('--odometer-duration', `${duration}ms`);
+        el.style.setProperty('--odometer-easing', easing);
+        el._odometerDigits = digits;
+    }
+
+    function runOdometer(el) {
+        const digits = el._odometerDigits;
+        if (!digits) return;
+        requestAnimationFrame(() => {
+            digits.forEach(({ seq, offset }) => {
+                seq.style.transform = `translateY(-${offset * 100}%)`;
+            });
+        });
     }
 
     // Populate item page from ITEMS data if present
@@ -175,10 +194,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 });
 
                 const statValues = statsContainer.querySelectorAll('.stat-value');
+                statValues.forEach(el => prepareOdometer(el));
                 const statsObserver = new IntersectionObserver((entries, obs) => {
                     entries.forEach(entry => {
                         if (entry.isIntersecting) {
-                            animateValue(entry.target);
+                            runOdometer(entry.target);
                             obs.unobserve(entry.target);
                         }
                     });

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -408,7 +408,8 @@ header .logo-text {
 }
 
 .item-page .characteristics-right img {
-  max-width: 100%;
+  width: 200%;
+  max-width: none;
   height: auto;
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -384,6 +384,8 @@ header .logo-text {
   position: relative;
   overflow: hidden;
   height: 1em;
+  width: 1ch;
+  display: inline-block;
 }
 
 .item-page .characteristics-stats .stat-value .digit-sequence {
@@ -392,6 +394,7 @@ header .logo-text {
   left: 0;
   display: flex;
   flex-direction: column;
+  width: 100%;
   transform: translateY(0);
   transition: transform var(--odometer-duration, 2000ms) var(--odometer-easing, cubic-bezier(0.25, 0.1, 0.25, 1));
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -376,6 +376,29 @@ header .logo-text {
 
 .item-page .characteristics-stats .stat-value {
   font-size: 48px;
+  display: flex;
+  font-variant-numeric: tabular-nums;
+}
+
+.item-page .characteristics-stats .stat-value .odometer-digit {
+  position: relative;
+  overflow: hidden;
+  height: 1em;
+}
+
+.item-page .characteristics-stats .stat-value .digit-sequence {
+  position: absolute;
+  top: 0;
+  left: 0;
+  display: flex;
+  flex-direction: column;
+  transform: translateY(0);
+  transition: transform var(--odometer-duration, 2000ms) var(--odometer-easing, cubic-bezier(0.25, 0.1, 0.25, 1));
+}
+
+.item-page .characteristics-stats .stat-value .digit-sequence span {
+  height: 1em;
+  line-height: 1em;
 }
 
 .item-page .characteristics-stats .stat-desc {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -343,6 +343,86 @@ header .logo-text {
   border-color: #000;
 }
 
+.item-page .characteristics-section {
+  padding: 60px 16px;
+}
+
+.item-page .characteristics-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 40px;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.item-page .characteristics-left {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  flex: 1;
+}
+
+.item-page .characteristics-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.item-page .characteristics-stats .stat-item {
+  display: flex;
+  flex-direction: column;
+}
+
+.item-page .characteristics-stats .stat-value {
+  font-size: 48px;
+}
+
+.item-page .characteristics-stats .stat-desc {
+  font-size: 14px;
+  opacity: 0.7;
+}
+
+.item-page .all-specs-btn {
+  align-self: flex-start;
+  padding: 10px 20px;
+  border: 1px solid #000;
+  border-radius: 8px;
+  background: #fff;
+  color: #000;
+  font-size: 16px;
+  cursor: pointer;
+  transition: background 0.3s, color 0.3s;
+}
+
+.item-page .all-specs-btn:hover,
+.item-page .all-specs-btn:active {
+  background: #000;
+  color: #fff;
+}
+
+.item-page .characteristics-right {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
+.item-page .characteristics-right img {
+  max-width: 100%;
+  height: auto;
+}
+
+@media (max-width: 768px) {
+  .item-page .characteristics-container {
+    flex-direction: column;
+    text-align: center;
+  }
+
+  .item-page .all-specs-btn {
+    align-self: center;
+  }
+}
+
 @media (min-width: 1024px) {
   .catalog {
     grid-template-columns: repeat(3, 1fr);

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -396,7 +396,7 @@ header .logo-text {
   flex-direction: column;
   width: 100%;
   transform: translateY(0);
-  transition: transform var(--odometer-duration, 2000ms) var(--odometer-easing, cubic-bezier(0.25, 0.1, 0.25, 1));
+  transition: transform var(--odometer-duration, 5000ms) var(--odometer-easing, cubic-bezier(0.33, 1, 0.68, 1));
 }
 
 .item-page .characteristics-stats .stat-value .digit-sequence span {

--- a/item.html
+++ b/item.html
@@ -58,9 +58,16 @@
       </div>
       <h2 class="item-title"></h2>
     </section>
-    <section id="characteristics">
-      <h2>Характеристики</h2>
-      <p>Здесь будут технические характеристики товара.</p>
+    <section id="characteristics" class="characteristics-section">
+      <div class="characteristics-container">
+        <div class="characteristics-left">
+          <div class="characteristics-stats"></div>
+          <button class="all-specs-btn">Все технические характеристики</button>
+        </div>
+        <div class="characteristics-right">
+          <img src="" alt="" />
+        </div>
+      </div>
     </section>
     <section id="configurator">
       <h2>Конфигуратор</h2>


### PR DESCRIPTION
## Summary
- display characteristic stats alongside secondary item image
- style characteristics section with responsive layout and call-to-action button
- load item characteristics data dynamically from items.js

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b6b2998c832caeccbe54f17ec146