### PR TITLE
Replace local hero images with remote placeholders

### DIFF
--- a/assets/configurator.js
+++ b/assets/configurator.js
@@ -29,7 +29,7 @@ const products = [
     id: "m3",
     name: "Чешуирователь Ultra 1200",
     badge: "Ni-сплав",
-    img: "assets/images/item3.png",
+    img: "https://images-porsche.imgix.net/-/media/0683EEF17ADA4D6ABAA276C65235E96C_29BC6C3357784A859B8A0E4B36EE15F8_CZ25W14IX0010-911-carrera-4-gts-side?w=2560&h=697&q=85&crop=faces%2Centropy%2Cedges&auto=format",
     specs: [
       "Разгон 0–100 кг/ч",
       "Мощность: 9.0 кВт",

--- a/assets/images/PLACEHOLDERS.md
+++ b/assets/images/PLACEHOLDERS.md
@@ -1,0 +1,6 @@
+# Hero media placeholders
+
+Responsive hero assets for each catalog item can be added here as multi-size PNG/WEBP files (e.g. `item1_pic1-800.png`).
+The repository now relies on remote placeholder URLs (see `assets/items.js`) instead of bundling the heavyweight PNG
+variants. If you want to work with local images, drop the responsive files into this folder and update the corresponding
+item metadata to point at them.

--- a/assets/items.js
+++ b/assets/items.js
@@ -1,7 +1,20 @@
+const REMOTE_MEDIA = {
+  item3: 'https://images-porsche.imgix.net/-/media/0683EEF17ADA4D6ABAA276C65235E96C_29BC6C3357784A859B8A0E4B36EE15F8_CZ25W14IX0010-911-carrera-4-gts-side?w=2560&h=697&q=85&crop=faces%2Centropy%2Cedges&auto=format',
+  item4: 'https://images-porsche.imgix.net/-/media/29200583E46C486581905B15B7F99E2A_C9D24F865FEE489D848D0D5D1A3FB656_CZ25W02IX0010-911-carrera-cabrio-side?w=2560&h=697&q=85&crop=faces%2Centropy%2Cedges&auto=format',
+  airpods: 'https://images-porsche.imgix.net/-/media/C4E673973FFF4E3BB35A85C8BBBB3984_9593233136744700A12A1AE0DE9D5791_CZ26W07IX0010-911-targa-4s-side?w=2560&h=697&q=85&crop=faces%2Centropy%2Cedges&auto=format',
+  mac: 'https://images-porsche.imgix.net/-/media/646ED7CDD4DF4060A4823F3A9DB8DA22_97CB2E119D8749C19004EC939CD09E96_CZ25W01IX0010911-carrera-side?w=2800&q=45&crop=faces%2Centropy%2Cedges&auto=format'
+};
+
 const ITEMS = {
   item1: {
     title: 'МАШИНА ЧЕШУИРОВАНИЯ',
     image: 'assets/images/item1_pic1.png',
+    hero: {
+      base: 'assets/images/item1_pic1',
+      type: 'png',
+      widths: []
+    },
+    detailImage: 'assets/images/item1_pic2.png',
     characteristics: [
       { value: '4,1 с', description: 'Разгон 0–100 км/ч' },
       { value: '290 кВт / 394 л.с.', description: 'Мощность' },
@@ -11,6 +24,12 @@ const ITEMS = {
   item2: {
     title: 'БАРАБАННОЕ ОБОРУДОВАНИЕ',
     image: 'assets/images/item2_pic1.png',
+    hero: {
+      base: 'assets/images/item2_pic1',
+      type: 'png',
+      widths: []
+    },
+    detailImage: 'assets/images/item2.png',
     characteristics: [
       { value: '4,1 с', description: 'Разгон 0–100 км/ч' },
       { value: '290 кВт / 394 л.с.', description: 'Мощность' },
@@ -19,7 +38,12 @@ const ITEMS = {
   },
   item3: {
     title: 'КОМПРЕССОРНОЕ ОБОРУДОВАНИЕ',
-    image: 'assets/images/item3.png',
+    image: REMOTE_MEDIA.item3,
+    hero: {
+      src: REMOTE_MEDIA.item3,
+      widths: []
+    },
+    detailImage: REMOTE_MEDIA.item3,
     characteristics: [
       { value: '4,1 с', description: 'Разгон 0–100 км/ч' },
       { value: '290 кВт / 394 л.с.', description: 'Мощность' },
@@ -28,7 +52,12 @@ const ITEMS = {
   },
   item4: {
     title: 'ЁМКОСТИ И РЕЗЕРВУАРЫ',
-    image: 'assets/images/item4.png',
+    image: REMOTE_MEDIA.item4,
+    hero: {
+      src: REMOTE_MEDIA.item4,
+      widths: []
+    },
+    detailImage: REMOTE_MEDIA.item4,
     characteristics: [
       { value: '4,1 с', description: 'Разгон 0–100 км/ч' },
       { value: '290 кВт / 394 л.с.', description: 'Мощность' },
@@ -37,7 +66,12 @@ const ITEMS = {
   },
   item5: {
     title: 'ТЕПЛООБМЕННОЕ ОБОРУДОВАНИЕ',
-    image: 'assets/images/airpods.png',
+    image: REMOTE_MEDIA.airpods,
+    hero: {
+      src: REMOTE_MEDIA.airpods,
+      widths: []
+    },
+    detailImage: REMOTE_MEDIA.airpods,
     characteristics: [
       { value: '4,1 с', description: 'Разгон 0–100 км/ч' },
       { value: '290 кВт / 394 л.с.', description: 'Мощность' },
@@ -46,7 +80,12 @@ const ITEMS = {
   },
   item6: {
     title: 'iMac 24″',
-    image: 'assets/images/mac.png',
+    image: REMOTE_MEDIA.mac,
+    hero: {
+      src: REMOTE_MEDIA.mac,
+      widths: []
+    },
+    detailImage: REMOTE_MEDIA.mac,
     characteristics: [
       { value: '4,1 с', description: 'Разгон 0–100 км/ч' },
       { value: '290 кВт / 394 л.с.', description: 'Мощность' },

--- a/assets/script.js
+++ b/assets/script.js
@@ -138,33 +138,172 @@ document.addEventListener('DOMContentLoaded', () => {
         requestAnimationFrame(update);
     }
 
+    const HERO_SIZES = '(min-width: 1440px) 1200px, 92vw';
+    const createSrcSet = (base, widths, extension) => {
+        const cleanExt = extension.startsWith('.') ? extension.slice(1) : extension;
+        return widths
+            .filter((value, index, array) => array.indexOf(value) === index)
+            .sort((a, b) => a - b)
+            .map(width => `${base}-${width}.${cleanExt} ${width}w`)
+            .join(', ');
+    };
+
     // Populate item page from ITEMS data if present
     if (document.body.classList.contains('item-page') && typeof ITEMS !== 'undefined') {
         const params = new URLSearchParams(window.location.search);
         const itemId = params.get('id');
         if (itemId && ITEMS[itemId]) {
-            const { title, image, characteristics } = ITEMS[itemId];
+            const { title, image, hero, detailImage, characteristics } = ITEMS[itemId];
             const titleEl = document.querySelector('.item-title');
-            const imageEl = document.querySelector('#image-wrapper img');
+            const heroPicture = document.querySelector('#hero-picture');
+            const heroImageEl = heroPicture ? heroPicture.querySelector('img') : null;
+            const heroSourceWebp = heroPicture ? heroPicture.querySelector('source[type="image/webp"]') : null;
             if (titleEl) {
                 titleEl.textContent = title;
                 document.title = title;
                 titleEl.classList.add(`${itemId}-title`);
 
             }
-            if (imageEl) {
-                imageEl.src = image;
-                imageEl.alt = itemId;
+            if (heroImageEl) {
+                heroImageEl.alt = title;
+            }
+
+            if (hero && heroImageEl) {
+                const { base, type = 'png', widths = [], src, srcset, sources } = hero;
+                const cleanExt = typeof type === 'string' && type.startsWith('.') ? type.slice(1) : type;
+                const widthValues = Array.isArray(widths) ? widths : [];
+                const hasBase = typeof base === 'string' && base.length > 0;
+                const sortedWidths = hasBase
+                    ? widthValues
+                        .filter((value, index, array) => array.indexOf(value) === index)
+                        .sort((a, b) => a - b)
+                    : [];
+                const hasGeneratedWidths = hasBase && sortedWidths.length > 0;
+
+                if (heroSourceWebp) {
+                    const webpConfig = sources && sources.webp;
+                    if (typeof webpConfig === 'string' && webpConfig.trim()) {
+                        heroSourceWebp.srcset = webpConfig;
+                    } else if (webpConfig && typeof webpConfig === 'object') {
+                        const { srcset: webpSrcset = '', sizes: webpSizes } = webpConfig;
+                        if (webpSrcset.trim()) {
+                            heroSourceWebp.srcset = webpSrcset;
+                            if (webpSizes) {
+                                heroSourceWebp.sizes = webpSizes;
+                            }
+                        } else {
+                            heroSourceWebp.removeAttribute('srcset');
+                            heroSourceWebp.removeAttribute('sizes');
+                            heroSourceWebp.remove();
+                        }
+                    } else if (hasGeneratedWidths) {
+                        heroSourceWebp.srcset = createSrcSet(base, sortedWidths, 'webp');
+                    } else {
+                        heroSourceWebp.removeAttribute('srcset');
+                        heroSourceWebp.removeAttribute('sizes');
+                        heroSourceWebp.remove();
+                    }
+                }
+
+                let finalSrc = typeof src === 'string' && src.trim() ? src : '';
+                let finalSrcset = typeof srcset === 'string' && srcset.trim() ? srcset : '';
+
+                if (hasGeneratedWidths) {
+                    const generatedSrcset = createSrcSet(base, sortedWidths, cleanExt);
+                    if (!finalSrcset) {
+                        finalSrcset = generatedSrcset;
+                    }
+                    if (!finalSrc) {
+                        const preferredWidth = sortedWidths.find(width => width >= 1200) ?? sortedWidths[sortedWidths.length - 1];
+                        finalSrc = `${base}-${preferredWidth}.${cleanExt}`;
+                    }
+                } else if (!finalSrc && hasBase) {
+                    finalSrc = `${base}.${cleanExt}`;
+                }
+
+                if (!finalSrc && image) {
+                    finalSrc = image;
+                }
+
+                if (finalSrc) {
+                    heroImageEl.src = finalSrc;
+                } else {
+                    heroImageEl.removeAttribute('src');
+                }
+
+                if (finalSrcset) {
+                    heroImageEl.srcset = finalSrcset;
+                } else {
+                    heroImageEl.removeAttribute('srcset');
+                }
+
+                const hasWidthDescriptor = typeof finalSrcset === 'string' && /\s\d+w/.test(finalSrcset);
+                const webpSrcsetValue = heroSourceWebp ? heroSourceWebp.getAttribute('srcset') || '' : '';
+                const webpHasWidthDescriptor = /\s\d+w/.test(webpSrcsetValue);
+                if (hasWidthDescriptor) {
+                    heroImageEl.sizes = HERO_SIZES;
+                    if (heroSourceWebp && webpSrcsetValue) {
+                        if (webpHasWidthDescriptor) {
+                            heroSourceWebp.sizes = heroSourceWebp.getAttribute('sizes') || HERO_SIZES;
+                        } else {
+                            heroSourceWebp.removeAttribute('sizes');
+                        }
+                    }
+                } else {
+                    heroImageEl.removeAttribute('sizes');
+                    if (heroSourceWebp) {
+                        heroSourceWebp.removeAttribute('sizes');
+                    }
+                }
+            } else if (heroImageEl && image) {
+                heroImageEl.src = image;
+                heroImageEl.srcset = image;
+                heroImageEl.removeAttribute('sizes');
+                if (heroSourceWebp) {
+                    heroSourceWebp.removeAttribute('srcset');
+                    heroSourceWebp.removeAttribute('sizes');
+                    heroSourceWebp.remove();
+                }
             }
 
             const charImgEl = document.querySelector('#characteristics img');
             if (charImgEl) {
-                let secondaryImage = image.replace(/_pic1(\.[a-z]+)$/i, '_pic2$1');
-                if (secondaryImage === image) {
-                    secondaryImage = image.replace(/(\.[a-z]+)$/i, '_pic2$1');
+                let secondaryImage = detailImage || '';
+
+                if (!secondaryImage && typeof image === 'string') {
+                    secondaryImage = image.replace(/_pic1(\.[a-z]+)$/i, '_pic2$1');
+                    if (secondaryImage === image) {
+                        secondaryImage = image.replace(/(\.[a-z]+)$/i, '_pic2$1');
+                    }
                 }
-                charImgEl.src = secondaryImage;
-                charImgEl.alt = itemId + ' details';
+
+                if ((!secondaryImage || secondaryImage === image) && hero) {
+                    const { base, type = 'png', widths = [], src, preview } = hero;
+                    if (preview && typeof preview === 'string') {
+                        secondaryImage = preview;
+                    } else if (src && typeof src === 'string' && src.trim()) {
+                        secondaryImage = src;
+                    } else if (base && typeof base === 'string') {
+                        const cleanExt = type.startsWith('.') ? type.slice(1) : type;
+                        const widthValues = Array.isArray(widths) ? widths : [];
+                        const sortedWidths = widthValues
+                            .filter((value, index, array) => array.indexOf(value) === index)
+                            .sort((a, b) => a - b);
+                        const previewWidth = sortedWidths.find(width => width >= 800) ?? sortedWidths[0];
+                        secondaryImage = previewWidth
+                            ? `${base}-${previewWidth}.${cleanExt}`
+                            : `${base}.${cleanExt}`;
+                    }
+                }
+
+                if (!secondaryImage && heroImageEl) {
+                    secondaryImage = heroImageEl.currentSrc || heroImageEl.src;
+                }
+
+                if (secondaryImage) {
+                    charImgEl.src = secondaryImage;
+                    charImgEl.alt = `${title} details`;
+                }
             }
 
             const statsContainer = document.querySelector('.characteristics-stats');

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -393,7 +393,8 @@ header .logo-text {
   display: flex;
   flex-direction: column;
   gap: 30px;
-  flex: 1;
+  flex: 0 1 40%;
+  max-width: 40%;
 }
 
 .item-page .characteristics-stats {
@@ -435,7 +436,8 @@ header .logo-text {
 }
 
 .item-page .characteristics-right {
-  flex: 1;
+  flex: 0 1 60%;
+  max-width: 60%;
   display: flex;
   justify-content: center;
 }
@@ -446,6 +448,12 @@ header .logo-text {
   .item-page .characteristics-container {
     flex-direction: column;
     text-align: center;
+  }
+
+  .item-page .characteristics-left,
+  .item-page .characteristics-right {
+    flex: 0 0 100%;
+    max-width: none;
   }
 
   .item-page .all-specs-btn {

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -259,6 +259,7 @@ header .logo-text {
   position: relative;
   z-index: 1;
   display: block;
+  margin-inline: auto;
   width: min(100%, var(--hero-max));
   height: auto;
   object-fit: contain;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -39,6 +39,9 @@ html {
   --color-text: #333333;
   --color-primary: #0057B8;
   --color-accent: #FF6A00;
+  --page-max: 1440px;
+  --pad-inline: clamp(16px, 4vw, 96px);
+  --hero-max: 1200px;
 }
 
 body {
@@ -77,6 +80,13 @@ h2 {
 
 h3 {
   font-size: 24px;
+}
+
+.page,
+.main-layout {
+  max-width: var(--page-max);
+  margin-inline: auto;
+  padding-inline: var(--pad-inline);
 }
 
 header {
@@ -237,23 +247,27 @@ header .logo-text {
 }
 
 .item-page .image-wrapper {
-  display: flex;
-  justify-content: center;
   position: relative;
+  display: grid;
+  place-items: center;
   width: 100%;
-  overflow: visible;
+  min-height: clamp(240px, 40vw, 560px);
+  overflow: clip;
 }
 
 .item-page .image-wrapper img {
-  width: 100vw;
-  max-width: 100vw;
+  position: relative;
+  z-index: 1;
+  display: block;
+  width: min(100%, var(--hero-max));
   height: auto;
+  object-fit: contain;
 }
 
 .item-page .characteristics-right img {
-  width: 170%;
-  max-width: 170%;
+  width: min(100%, 720px);
   height: auto;
+  object-fit: contain;
 }
 
 .item-page .main-section {
@@ -306,31 +320,30 @@ header .logo-text {
   border-color: #fff;
 }
 
-.item-page .image-wrapper::before {
+.item-page .image-wrapper::after {
   content: "";
   position: absolute;
-  bottom: 35%;
   left: 50%;
+  bottom: 8%;
   transform: translateX(-50%);
-  width: 100vw;
-  height: 30%;
-  background: linear-gradient(to bottom, rgba(255, 255, 255, 0.95), #e0e0e0);
-  z-index: -1;
-  opacity: 0;
-  animation: gradientFade 4s ease forwards;
-}
-
-@keyframes gradientFade {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  width: min(100%, var(--hero-max));
+  height: clamp(40px, 10vw, 120px);
+  background: radial-gradient(60% 100% at 50% 50%, rgba(0, 0, 0, 0.25), transparent 70%);
+  opacity: 0.35;
+  filter: blur(6px);
+  pointer-events: none;
 }
 
 .item-page .item-title {
   text-align: center;
-  margin: 0;
-  margin-top: -80px;
+  margin: clamp(8px, 2.4vw, 24px) 0 0;
   padding: 0 0 20px;
-  font-size: 36px;
+  font-size: clamp(28px, 4.8vw, 56px);
+  line-height: 1.1;
+}
+
+.item-page .characteristics-stats .stat-value {
+  font-size: clamp(26px, 4.2vw, 54px);
 }
 
 .item-page .item-title.item1-title {

--- a/catalog.html
+++ b/catalog.html
@@ -102,7 +102,7 @@
             </div>
           </div>
           <div class="catalog-item">
-            <img src="assets/images/airpods.png" alt="AirPods Pro" class="catalog-bg" />
+            <img src="https://images-porsche.imgix.net/-/media/C4E673973FFF4E3BB35A85C8BBBB3984_9593233136744700A12A1AE0DE9D5791_CZ26W07IX0010-911-targa-4s-side?w=2560&amp;h=697&amp;q=85&amp;crop=faces%2Centropy%2Cedges&amp;auto=format" alt="AirPods Pro" class="catalog-bg" />
             <div class="catalog-content">
               <h3>AirPods Pro</h3>
               <div class="catalog-footer">
@@ -112,7 +112,7 @@
             </div>
           </div>
           <div class="catalog-item">
-            <img src="assets/images/mac.png" alt="iMac 24″" class="catalog-bg" />
+            <img src="https://images-porsche.imgix.net/-/media/646ED7CDD4DF4060A4823F3A9DB8DA22_97CB2E119D8749C19004EC939CD09E96_CZ25W01IX0010911-carrera-side?w=2800&amp;q=45&amp;crop=faces%2Centropy%2Cedges&amp;auto=format" alt="iMac 24″" class="catalog-bg" />
             <div class="catalog-content">
               <h3>iMac 24″</h3>
               <div class="catalog-footer">

--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
           </div>
           <div class="catalog-item">
             <div class="catalog-image">
-              <img src="assets/images/item3.png" alt="Apple Watch" />
+              <img src="https://images-porsche.imgix.net/-/media/0683EEF17ADA4D6ABAA276C65235E96C_29BC6C3357784A859B8A0E4B36EE15F8_CZ25W14IX0010-911-carrera-4-gts-side?w=2560&amp;h=697&amp;q=85&amp;crop=faces%2Centropy%2Cedges&amp;auto=format" alt="КОМПРЕССОРНОЕ ОБОРУДОВАНИЕ" />
             </div>
             <div class="catalog-content">
               <h3>КОМПРЕССОРНОЕ ОБОРУДОВАНИЕ</h3>
@@ -131,7 +131,7 @@
           </div>
           <div class="catalog-item">
             <div class="catalog-image">
-              <img src="assets/images/item4.png" alt="iPhone 15" />
+              <img src="https://images-porsche.imgix.net/-/media/29200583E46C486581905B15B7F99E2A_C9D24F865FEE489D848D0D5D1A3FB656_CZ25W02IX0010-911-carrera-cabrio-side?w=2560&amp;h=697&amp;q=85&amp;crop=faces%2Centropy%2Cedges&amp;auto=format" alt="ЁМКОСТИ И РЕЗЕРВУАРЫ" />
             </div>
             <div class="catalog-content">
               <h3>ЕМКОСТИ И РЕЗЕРВУАРЫ</h3>
@@ -143,7 +143,7 @@
           </div>
           <div class="catalog-item">
             <div class="catalog-image">
-              <img src="assets/images/airpods.png" alt="AirPods Pro" />
+              <img src="https://images-porsche.imgix.net/-/media/C4E673973FFF4E3BB35A85C8BBBB3984_9593233136744700A12A1AE0DE9D5791_CZ26W07IX0010-911-targa-4s-side?w=2560&amp;h=697&amp;q=85&amp;crop=faces%2Centropy%2Cedges&amp;auto=format" alt="ТЕПЛООБМЕННОЕ ОБОРУДОВАНИЕ" />
             </div>
             <div class="catalog-content">
               <h3>ТЕПЛООБМЕННОЕ ОБОРУДОВАНИЕ</h3>
@@ -155,7 +155,7 @@
           </div>
           <div class="catalog-item">
             <div class="catalog-image">
-              <img src="assets/images/mac.png" alt="iMac 24″" />
+              <img src="https://images-porsche.imgix.net/-/media/646ED7CDD4DF4060A4823F3A9DB8DA22_97CB2E119D8749C19004EC939CD09E96_CZ25W01IX0010911-carrera-side?w=2800&amp;q=45&amp;crop=faces%2Centropy%2Cedges&amp;auto=format" alt="iMac 24″" />
             </div>
             <div class="catalog-content">
               <h3>iMac 24″</h3>

--- a/item.html
+++ b/item.html
@@ -64,10 +64,19 @@
           <a href="#model3d" class="item-nav-btn">3D-модель</a>
         </nav>
         <div id="image-wrapper" class="image-wrapper">
-          <img src="" alt="" />
+          <picture id="hero-picture">
+            <source type="image/webp" srcset="" sizes="(min-width: 1440px) 1200px, 92vw" />
+            <img
+              id="hero-image"
+              src=""
+              srcset=""
+              sizes="(min-width: 1440px) 1200px, 92vw"
+              alt=""
+            />
+          </picture>
         </div>
       </div>
-      <h2 class="item-title"></h2>
+      <h1 class="item-title"></h1>
     </section>
     <section id="characteristics" class="characteristics-section">
       <div class="characteristics-container">


### PR DESCRIPTION
## Summary
- switch catalog and configurator listings to the new remote hero placeholders supplied by the brief
- update item metadata and the hero loader so full URLs without responsive variants are handled cleanly
- refresh the hero media placeholder docs to clarify the remote-image workflow and remove the bundled PNGs

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cd5f408e8c832c8d20201a158769d8