### PR TITLE
Tighten item characteristics layout spacing

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -251,8 +251,8 @@ header .logo-text {
 }
 
 .item-page .characteristics-right img {
-  width: 170%;
-  max-width: 170%;
+  width: 255%;
+  max-width: 255%;
   height: auto;
 }
 
@@ -370,7 +370,7 @@ header .logo-text {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 40px;
+  gap: 20px;
   max-width: 1500px;
   margin: 0 auto;
 }


### PR DESCRIPTION
## Summary
- decrease the gap between the characteristics text and image blocks on the item page for a tighter layout
- enlarge the secondary characteristics image to display itemX_pic2 at 1.5x the previous size

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cd77276690832c8837be8cd87d9a78