### PR TITLE
Adjust item page hero layout

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -244,6 +244,7 @@ header .logo-text {
   display: flex;
   flex-direction: column;
   min-height: 100vh;
+  --hero-max: 760px;
 }
 
 .item-page .image-wrapper {
@@ -266,9 +267,12 @@ header .logo-text {
 }
 
 .item-page .characteristics-right img {
-  width: min(100%, 720px);
+  display: block;
+  width: min(100%, var(--hero-max));
   height: auto;
   object-fit: contain;
+  transform-origin: center left;
+  transform: translateX(-2vw) scale(1.5);
 }
 
 .item-page .main-section {
@@ -381,10 +385,10 @@ header .logo-text {
 }
 
 .item-page .characteristics-container {
-  display: flex;
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  column-gap: clamp(12px, 2.5vw, 24px);
   align-items: center;
-  justify-content: space-between;
-  gap: 40px;
   max-width: 1500px;
   margin: 0 auto;
 }
@@ -435,17 +439,39 @@ header .logo-text {
 }
 
 .item-page .characteristics-right {
-  flex: 1;
   display: flex;
-  justify-content: center;
+  justify-content: flex-start;
+  align-items: center;
+  margin-left: clamp(-24px, -2vw, -48px);
+  overflow: clip;
 }
 
 
 
+@media (max-width: 1024px) {
+  .item-page .characteristics-container {
+    grid-template-columns: 1fr;
+    row-gap: clamp(24px, 4vw, 40px);
+  }
+
+  .item-page .characteristics-right {
+    justify-content: center;
+    margin-left: 0;
+  }
+
+  .item-page .characteristics-right img {
+    transform: none;
+    width: min(100%, 640px);
+  }
+}
+
 @media (max-width: 768px) {
   .item-page .characteristics-container {
-    flex-direction: column;
     text-align: center;
+  }
+
+  .item-page .characteristics-left {
+    align-items: center;
   }
 
   .item-page .all-specs-btn {


### PR DESCRIPTION
## Summary
- tighten the item-page KPI and render layout by switching to a grid with a smaller column gap and left shift
- scale the equipment render while constraining its bounds and restoring default sizing on narrower screens

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd94ff1904832c941875bc888bea27